### PR TITLE
feat(commands): implement aidev remove agent command (US-07)

### DIFF
--- a/messages/aidev.remove.agent.md
+++ b/messages/aidev.remove.agent.md
@@ -1,0 +1,45 @@
+# summary
+
+Remove an installed agent.
+
+# description
+
+Remove a previously installed agent from your project. The agent files will be deleted and unregistered from the ai-dev configuration. By default, a confirmation prompt is shown before removal.
+
+# flags.name.summary
+
+Name of the agent to remove.
+
+# flags.no-prompt.summary
+
+Skip the confirmation prompt.
+
+# examples
+
+- Remove an agent named "my-agent":
+
+  <%= config.bin %> <%= command.id %> --name my-agent
+
+- Remove without confirmation:
+
+  <%= config.bin %> <%= command.id %> --name my-agent --no-prompt
+
+# prompt.ConfirmRemove
+
+Are you sure you want to remove agent "%s"?
+
+# error.NotInstalled
+
+Agent "%s" is not installed.
+
+# error.RemoveFailed
+
+Failed to remove agent "%s": %s
+
+# info.AgentRemoved
+
+Successfully removed agent "%s".
+
+# info.Cancelled
+
+Removal cancelled.

--- a/src/commands/aidev/remove/agent.ts
+++ b/src/commands/aidev/remove/agent.ts
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2024, Yury Bondarau
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ */
+
+import { SfCommand, Flags } from '@salesforce/sf-plugins-core';
+import { Messages, SfError } from '@salesforce/core';
+import { ArtifactService } from '../../../services/artifactService.js';
+import { AiDevConfig } from '../../../config/aiDevConfig.js';
+
+Messages.importMessagesDirectoryFromMetaUrl(import.meta.url);
+const messages = Messages.loadMessages('ai-dev', 'aidev.remove.agent');
+
+export interface RemoveAgentResult {
+  success: boolean;
+  name: string;
+  error?: string;
+}
+
+export default class RemoveAgent extends SfCommand<RemoveAgentResult> {
+  public static readonly summary = messages.getMessage('summary');
+  public static readonly description = messages.getMessage('description');
+  public static readonly examples = messages.getMessages('examples');
+  public static readonly enableJsonFlag = true;
+
+  public static readonly flags = {
+    name: Flags.string({
+      char: 'n',
+      summary: messages.getMessage('flags.name.summary'),
+      required: true,
+    }),
+    'no-prompt': Flags.boolean({
+      summary: messages.getMessage('flags.no-prompt.summary'),
+      default: false,
+    }),
+  };
+
+  public async run(): Promise<RemoveAgentResult> {
+    const { flags } = await this.parse(RemoveAgent);
+
+    const config = await AiDevConfig.create({ isGlobal: false });
+    const service = new ArtifactService(config, process.cwd());
+
+    // Check if agent is installed
+    if (!service.isInstalled(flags.name, 'agent')) {
+      throw new SfError(messages.getMessage('error.NotInstalled', [flags.name]), 'NotInstalledError');
+    }
+
+    // Confirm removal unless --no-prompt is specified
+    if (!flags['no-prompt']) {
+      const confirmed = await this.confirm({
+        message: messages.getMessage('prompt.ConfirmRemove', [flags.name]),
+      });
+      if (!confirmed) {
+        this.log(messages.getMessage('info.Cancelled'));
+        return { success: false, name: flags.name, error: 'User cancelled removal' };
+      }
+    }
+
+    const result = await service.uninstall(flags.name, { type: 'agent' });
+
+    if (!result.success) {
+      throw new SfError(
+        messages.getMessage('error.RemoveFailed', [flags.name, result.error ?? 'Unknown error']),
+        'RemoveError'
+      );
+    }
+
+    this.log(messages.getMessage('info.AgentRemoved', [flags.name]));
+    return { success: true, name: flags.name };
+  }
+}

--- a/test/commands/aidev/remove/agent.test.ts
+++ b/test/commands/aidev/remove/agent.test.ts
@@ -1,0 +1,152 @@
+/*
+ * Copyright (c) 2024, Yury Bondarau
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ */
+
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { Config } from '@oclif/core';
+import { SfCommand } from '@salesforce/sf-plugins-core';
+import RemoveAgent from '../../../../src/commands/aidev/remove/agent.js';
+import { ArtifactService } from '../../../../src/services/artifactService.js';
+import { AiDevConfig } from '../../../../src/config/aiDevConfig.js';
+
+describe('aidev remove agent', () => {
+  let sandbox: sinon.SinonSandbox;
+  let isInstalledStub: sinon.SinonStub;
+  let uninstallStub: sinon.SinonStub;
+  let confirmStub: sinon.SinonStub;
+  let oclifConfig: Config;
+
+  before(async () => {
+    oclifConfig = await Config.load({ root: process.cwd() });
+  });
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+    sandbox.stub(AiDevConfig, 'create').resolves({} as AiDevConfig);
+    isInstalledStub = sandbox.stub(ArtifactService.prototype, 'isInstalled');
+    uninstallStub = sandbox.stub(ArtifactService.prototype, 'uninstall');
+    confirmStub = sandbox.stub(SfCommand.prototype, 'confirm');
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  describe('successful removal', () => {
+    it('removes an agent with confirmation', async () => {
+      isInstalledStub.returns(true);
+      confirmStub.resolves(true);
+      uninstallStub.resolves({ success: true });
+
+      const result = await RemoveAgent.run(['--name', 'my-agent'], oclifConfig);
+
+      expect(result.success).to.be.true;
+      expect(result.name).to.equal('my-agent');
+      expect(confirmStub.calledOnce).to.be.true;
+      expect(uninstallStub.calledOnce).to.be.true;
+      expect(uninstallStub.firstCall.args[0]).to.equal('my-agent');
+      expect(uninstallStub.firstCall.args[1]).to.deep.equal({ type: 'agent' });
+    });
+
+    it('removes an agent with --no-prompt flag', async () => {
+      isInstalledStub.returns(true);
+      uninstallStub.resolves({ success: true });
+
+      const result = await RemoveAgent.run(['--name', 'my-agent', '--no-prompt'], oclifConfig);
+
+      expect(result.success).to.be.true;
+      expect(result.name).to.equal('my-agent');
+      expect(confirmStub.called).to.be.false;
+      expect(uninstallStub.calledOnce).to.be.true;
+    });
+
+    it('removes an agent using short flag -n', async () => {
+      isInstalledStub.returns(true);
+      confirmStub.resolves(true);
+      uninstallStub.resolves({ success: true });
+
+      const result = await RemoveAgent.run(['-n', 'my-agent'], oclifConfig);
+
+      expect(result.success).to.be.true;
+      expect(isInstalledStub.firstCall.args[0]).to.equal('my-agent');
+    });
+  });
+
+  describe('user cancellation', () => {
+    it('returns cancelled result when user denies confirmation', async () => {
+      isInstalledStub.returns(true);
+      confirmStub.resolves(false);
+
+      const result = await RemoveAgent.run(['--name', 'my-agent'], oclifConfig);
+
+      expect(result.success).to.be.false;
+      expect(result.name).to.equal('my-agent');
+      expect(result.error).to.equal('User cancelled removal');
+      expect(uninstallStub.called).to.be.false;
+    });
+  });
+
+  describe('error handling', () => {
+    it('throws SfError when agent is not installed', async () => {
+      isInstalledStub.returns(false);
+
+      const cmd = new RemoveAgent(['--name', 'not-installed'], oclifConfig);
+      try {
+        await cmd.run();
+        expect.fail('Should have thrown SfError');
+      } catch (error) {
+        expect(error).to.be.instanceOf(Error);
+        expect((error as Error).message).to.include('not-installed');
+        expect((error as Error).message).to.include('not installed');
+      }
+    });
+
+    it('throws SfError when uninstall fails', async () => {
+      isInstalledStub.returns(true);
+      confirmStub.resolves(true);
+      uninstallStub.resolves({ success: false, error: 'Directory deletion failed' });
+
+      const cmd = new RemoveAgent(['--name', 'my-agent'], oclifConfig);
+      try {
+        await cmd.run();
+        expect.fail('Should have thrown SfError');
+      } catch (error) {
+        expect(error).to.be.instanceOf(Error);
+        expect((error as Error).message).to.include('my-agent');
+        expect((error as Error).message).to.include('Directory deletion failed');
+      }
+    });
+
+    it('throws SfError with generic message when error is undefined', async () => {
+      isInstalledStub.returns(true);
+      confirmStub.resolves(true);
+      uninstallStub.resolves({ success: false });
+
+      const cmd = new RemoveAgent(['--name', 'my-agent'], oclifConfig);
+      try {
+        await cmd.run();
+        expect.fail('Should have thrown SfError');
+      } catch (error) {
+        expect(error).to.be.instanceOf(Error);
+        expect((error as Error).message).to.include('Unknown error');
+      }
+    });
+  });
+
+  describe('command metadata', () => {
+    it('has required static properties', () => {
+      expect(RemoveAgent.summary).to.be.a('string').and.not.be.empty;
+      expect(RemoveAgent.description).to.be.a('string').and.not.be.empty;
+      expect(RemoveAgent.examples).to.be.an('array').and.have.length.greaterThan(0);
+      expect(RemoveAgent.enableJsonFlag).to.be.true;
+    });
+
+    it('has correct flag definitions', () => {
+      expect(RemoveAgent.flags).to.have.property('name');
+      expect(RemoveAgent.flags).to.have.property('no-prompt');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Implement `aidev remove agent` command that removes installed agents
- Add confirmation prompt before removal (can be skipped with `--no-prompt`)
- Full test coverage for all code paths

## Related Issue

Closes #15

## Test plan

- [x] `yarn build` passes
- [x] `yarn test` passes with all tests passing
- [x] `yarn lint` passes with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)