### PR TITLE
feat(commands): implement aidev list artifacts command (US-05)

### DIFF
--- a/messages/aidev.list.artifacts.md
+++ b/messages/aidev.list.artifacts.md
@@ -1,0 +1,57 @@
+# summary
+
+List installed and available artifacts.
+
+# description
+
+List artifacts from your project and configured sources. By default, shows both installed and available artifacts. Use flags to filter by type (skill, agent, prompt) or show only installed/available artifacts.
+
+# flags.type.summary
+
+Filter by artifact type (skill, agent, prompt).
+
+# flags.installed.summary
+
+Show only installed artifacts.
+
+# flags.available.summary
+
+Show only available artifacts from sources.
+
+# flags.source.summary
+
+Filter available artifacts by source repository.
+
+# examples
+
+- List all artifacts:
+
+  <%= config.bin %> <%= command.id %>
+
+- List only installed artifacts:
+
+  <%= config.bin %> <%= command.id %> --installed
+
+- List only available skills:
+
+  <%= config.bin %> <%= command.id %> --available --type skill
+
+- List artifacts from a specific source:
+
+  <%= config.bin %> <%= command.id %> --source owner/repo
+
+# info.InstalledHeader
+
+Installed Artifacts:
+
+# info.NoInstalled
+
+No artifacts installed.
+
+# info.AvailableHeader
+
+Available Artifacts:
+
+# info.NoAvailable
+
+No artifacts available from configured sources.

--- a/src/commands/aidev/list/artifacts.ts
+++ b/src/commands/aidev/list/artifacts.ts
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2024, Yury Bondarau
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ */
+
+import { SfCommand, Flags } from '@salesforce/sf-plugins-core';
+import { Messages } from '@salesforce/core';
+import { ArtifactService, type AvailableArtifact } from '../../../services/artifactService.js';
+import { AiDevConfig } from '../../../config/aiDevConfig.js';
+import type { InstalledArtifact } from '../../../types/config.js';
+import type { ArtifactType } from '../../../types/manifest.js';
+
+Messages.importMessagesDirectoryFromMetaUrl(import.meta.url);
+const messages = Messages.loadMessages('ai-dev', 'aidev.list.artifacts');
+
+export interface ListArtifactsResult {
+  installed: InstalledArtifact[];
+  available: AvailableArtifact[];
+}
+
+export default class ListArtifacts extends SfCommand<ListArtifactsResult> {
+  public static readonly summary = messages.getMessage('summary');
+  public static readonly description = messages.getMessage('description');
+  public static readonly examples = messages.getMessages('examples');
+  public static readonly enableJsonFlag = true;
+
+  public static readonly flags = {
+    type: Flags.string({
+      char: 't',
+      summary: messages.getMessage('flags.type.summary'),
+      options: ['skill', 'agent', 'prompt'],
+    }),
+    installed: Flags.boolean({
+      char: 'i',
+      summary: messages.getMessage('flags.installed.summary'),
+      exclusive: ['available'],
+    }),
+    available: Flags.boolean({
+      char: 'a',
+      summary: messages.getMessage('flags.available.summary'),
+      exclusive: ['installed'],
+    }),
+    source: Flags.string({
+      char: 's',
+      summary: messages.getMessage('flags.source.summary'),
+    }),
+  };
+
+  public async run(): Promise<ListArtifactsResult> {
+    const { flags } = await this.parse(ListArtifacts);
+
+    const config = await AiDevConfig.create({ isGlobal: false });
+    const service = new ArtifactService(config, process.cwd());
+
+    const showInstalled = !flags.available;
+    const showAvailable = !flags.installed;
+
+    let installed: InstalledArtifact[] = [];
+    let available: AvailableArtifact[] = [];
+
+    const artifactType = flags.type as ArtifactType | undefined;
+
+    if (showInstalled) {
+      installed = service.listInstalled({ type: artifactType });
+    }
+
+    if (showAvailable) {
+      available = await service.listAvailable({ type: artifactType, source: flags.source });
+    }
+
+    this.displayResults(installed, available, showInstalled, showAvailable);
+
+    return { installed, available };
+  }
+
+  private displayResults(
+    installed: InstalledArtifact[],
+    available: AvailableArtifact[],
+    showInstalled: boolean,
+    showAvailable: boolean
+  ): void {
+    if (showInstalled) {
+      this.log(messages.getMessage('info.InstalledHeader'));
+      if (installed.length === 0) {
+        this.log(messages.getMessage('info.NoInstalled'));
+      } else {
+        for (const artifact of installed) {
+          this.log(`  ${artifact.type}: ${artifact.name} (from ${artifact.source})`);
+        }
+      }
+      this.log('');
+    }
+
+    if (showAvailable) {
+      this.log(messages.getMessage('info.AvailableHeader'));
+      if (available.length === 0) {
+        this.log(messages.getMessage('info.NoAvailable'));
+      } else {
+        for (const artifact of available) {
+          const status = artifact.installed ? '[installed]' : '';
+          this.log(`  ${artifact.type}: ${artifact.name} ${status}`.trimEnd());
+          if (artifact.description) {
+            this.log(`    ${artifact.description}`);
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/commands/aidev/list/artifacts.test.ts
+++ b/test/commands/aidev/list/artifacts.test.ts
@@ -1,0 +1,225 @@
+/*
+ * Copyright (c) 2024, Yury Bondarau
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ */
+
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { Config } from '@oclif/core';
+import ListArtifacts from '../../../../src/commands/aidev/list/artifacts.js';
+import { ArtifactService } from '../../../../src/services/artifactService.js';
+import { AiDevConfig } from '../../../../src/config/aiDevConfig.js';
+import type { InstalledArtifact } from '../../../../src/types/config.js';
+import type { AvailableArtifact } from '../../../../src/services/artifactService.js';
+
+describe('aidev list artifacts', () => {
+  let sandbox: sinon.SinonSandbox;
+  let listInstalledStub: sinon.SinonStub;
+  let listAvailableStub: sinon.SinonStub;
+  let oclifConfig: Config;
+
+  const installedArtifacts: InstalledArtifact[] = [
+    {
+      name: 'my-skill',
+      type: 'skill',
+      path: '.github/copilot-skills/my-skill.md',
+      source: 'owner/repo',
+      installedAt: '2024-01-01T00:00:00Z',
+    },
+    {
+      name: 'my-agent',
+      type: 'agent',
+      path: '.github/agents/my-agent/',
+      source: 'owner/repo',
+      installedAt: '2024-01-02T00:00:00Z',
+    },
+  ];
+
+  const availableArtifacts: AvailableArtifact[] = [
+    {
+      name: 'my-skill',
+      type: 'skill',
+      description: 'A test skill',
+      source: 'owner/repo',
+      installed: true,
+    },
+    {
+      name: 'other-skill',
+      type: 'skill',
+      description: 'Another skill',
+      source: 'owner/repo',
+      installed: false,
+    },
+    {
+      name: 'my-agent',
+      type: 'agent',
+      source: 'other/repo',
+      installed: false,
+    },
+  ];
+
+  before(async () => {
+    oclifConfig = await Config.load({ root: process.cwd() });
+  });
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+    sandbox.stub(AiDevConfig, 'create').resolves({} as AiDevConfig);
+    listInstalledStub = sandbox.stub(ArtifactService.prototype, 'listInstalled');
+    listAvailableStub = sandbox.stub(ArtifactService.prototype, 'listAvailable');
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  describe('list all artifacts', () => {
+    it('lists both installed and available artifacts', async () => {
+      listInstalledStub.returns(installedArtifacts);
+      listAvailableStub.resolves(availableArtifacts);
+
+      const result = await ListArtifacts.run([], oclifConfig);
+
+      expect(result.installed).to.deep.equal(installedArtifacts);
+      expect(result.available).to.deep.equal(availableArtifacts);
+      expect(listInstalledStub.calledOnce).to.be.true;
+      expect(listAvailableStub.calledOnce).to.be.true;
+    });
+
+    it('returns empty arrays when no artifacts', async () => {
+      listInstalledStub.returns([]);
+      listAvailableStub.resolves([]);
+
+      const result = await ListArtifacts.run([], oclifConfig);
+
+      expect(result.installed).to.deep.equal([]);
+      expect(result.available).to.deep.equal([]);
+    });
+  });
+
+  describe('--installed flag', () => {
+    it('shows only installed artifacts', async () => {
+      listInstalledStub.returns(installedArtifacts);
+
+      const result = await ListArtifacts.run(['--installed'], oclifConfig);
+
+      expect(result.installed).to.deep.equal(installedArtifacts);
+      expect(result.available).to.deep.equal([]);
+      expect(listInstalledStub.calledOnce).to.be.true;
+      expect(listAvailableStub.called).to.be.false;
+    });
+
+    it('works with short flag -i', async () => {
+      listInstalledStub.returns(installedArtifacts);
+
+      const result = await ListArtifacts.run(['-i'], oclifConfig);
+
+      expect(result.installed).to.deep.equal(installedArtifacts);
+      expect(listAvailableStub.called).to.be.false;
+    });
+  });
+
+  describe('--available flag', () => {
+    it('shows only available artifacts', async () => {
+      listAvailableStub.resolves(availableArtifacts);
+
+      const result = await ListArtifacts.run(['--available'], oclifConfig);
+
+      expect(result.installed).to.deep.equal([]);
+      expect(result.available).to.deep.equal(availableArtifacts);
+      expect(listInstalledStub.called).to.be.false;
+      expect(listAvailableStub.calledOnce).to.be.true;
+    });
+
+    it('works with short flag -a', async () => {
+      listAvailableStub.resolves(availableArtifacts);
+
+      const result = await ListArtifacts.run(['-a'], oclifConfig);
+
+      expect(result.available).to.deep.equal(availableArtifacts);
+      expect(listInstalledStub.called).to.be.false;
+    });
+  });
+
+  describe('--type flag', () => {
+    it('filters by artifact type', async () => {
+      listInstalledStub.returns([installedArtifacts[0]]);
+      listAvailableStub.resolves([availableArtifacts[0], availableArtifacts[1]]);
+
+      const result = await ListArtifacts.run(['--type', 'skill'], oclifConfig);
+
+      expect(listInstalledStub.firstCall.args[0]).to.deep.equal({ type: 'skill' });
+      expect(listAvailableStub.firstCall.args[0]).to.deep.include({ type: 'skill' });
+      expect(result.installed).to.have.lengthOf(1);
+      expect(result.available).to.have.lengthOf(2);
+    });
+
+    it('works with short flag -t', async () => {
+      listInstalledStub.returns([]);
+      listAvailableStub.resolves([]);
+
+      await ListArtifacts.run(['-t', 'agent'], oclifConfig);
+
+      expect(listInstalledStub.firstCall.args[0]).to.deep.equal({ type: 'agent' });
+    });
+  });
+
+  describe('--source flag', () => {
+    it('filters available artifacts by source', async () => {
+      listInstalledStub.returns(installedArtifacts);
+      listAvailableStub.resolves([availableArtifacts[0], availableArtifacts[1]]);
+
+      await ListArtifacts.run(['--source', 'owner/repo'], oclifConfig);
+
+      expect(listAvailableStub.firstCall.args[0]).to.deep.include({ source: 'owner/repo' });
+    });
+
+    it('works with short flag -s', async () => {
+      listInstalledStub.returns([]);
+      listAvailableStub.resolves([]);
+
+      await ListArtifacts.run(['-s', 'other/repo'], oclifConfig);
+
+      expect(listAvailableStub.firstCall.args[0]).to.deep.include({ source: 'other/repo' });
+    });
+  });
+
+  describe('combined flags', () => {
+    it('combines --available and --type flags', async () => {
+      listAvailableStub.resolves([availableArtifacts[2]]);
+
+      const result = await ListArtifacts.run(['--available', '--type', 'agent'], oclifConfig);
+
+      expect(result.installed).to.deep.equal([]);
+      expect(listInstalledStub.called).to.be.false;
+      expect(listAvailableStub.firstCall.args[0]).to.deep.include({ type: 'agent' });
+    });
+
+    it('combines --installed and --type flags', async () => {
+      listInstalledStub.returns([installedArtifacts[1]]);
+
+      const result = await ListArtifacts.run(['--installed', '--type', 'agent'], oclifConfig);
+
+      expect(result.available).to.deep.equal([]);
+      expect(listAvailableStub.called).to.be.false;
+      expect(listInstalledStub.firstCall.args[0]).to.deep.equal({ type: 'agent' });
+    });
+  });
+
+  describe('command metadata', () => {
+    it('has required static properties', () => {
+      expect(ListArtifacts.summary).to.be.a('string').and.not.be.empty;
+      expect(ListArtifacts.description).to.be.a('string').and.not.be.empty;
+      expect(ListArtifacts.examples).to.be.an('array').and.have.length.greaterThan(0);
+      expect(ListArtifacts.enableJsonFlag).to.be.true;
+    });
+
+    it('has correct flag definitions', () => {
+      expect(ListArtifacts.flags).to.have.property('type');
+      expect(ListArtifacts.flags).to.have.property('installed');
+      expect(ListArtifacts.flags).to.have.property('available');
+      expect(ListArtifacts.flags).to.have.property('source');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Implement `aidev list artifacts` command to show installed and available artifacts
- Supports filtering by type, installed/available status, and source
- Full test coverage for all code paths

## Related Issue

Closes #17

## Test plan

- [x] `yarn build` passes
- [x] `yarn test` passes with all tests passing
- [x] `yarn lint` passes with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)