### PR TITLE
feat(commands): implement aidev init command (US-01)

### DIFF
--- a/messages/aidev.init.md
+++ b/messages/aidev.init.md
@@ -1,0 +1,133 @@
+# summary
+
+Initialize AI development tools in your project.
+
+# description
+
+Detect AI tools in your project, configure a source repository, and install available artifacts. This command provides an interactive setup experience for AI-assisted development with your Salesforce project.
+
+# flags.tool.summary
+
+AI tool to configure (copilot, claude, cursor, windsurf, gemini, codex). Auto-detected if not specified.
+
+# flags.source.summary
+
+Source repository (owner/repo) to install artifacts from.
+
+# flags.no-install.summary
+
+Skip artifact installation, only configure tool and source.
+
+# flags.no-prompt.summary
+
+Skip confirmation prompts (for scripting).
+
+# examples
+
+- Initialize with auto-detection:
+
+  <%= config.bin %> <%= command.id %>
+
+- Initialize with specific tool:
+
+  <%= config.bin %> <%= command.id %> --tool copilot
+
+- Initialize with a source repository:
+
+  <%= config.bin %> <%= command.id %> --source owner/ai-dev-templates
+
+- Initialize without prompts (for CI/scripts):
+
+  <%= config.bin %> <%= command.id %> --no-prompt
+
+# info.DetectingTools
+
+Detecting AI tools in project...
+
+# info.SingleToolDetected
+
+Detected AI tool: %s
+
+# info.MultipleToolsDetected
+
+Multiple AI tools detected: %s
+
+# info.AutoSelectedTool
+
+Auto-selected tool: %s
+
+# info.ToolConfigured
+
+Configured AI tool: %s
+
+# info.UsingDefaultSource
+
+Using default source: %s
+
+# info.AddingSource
+
+Adding source %s...
+
+# info.SkippingInstall
+
+Skipping artifact installation (--no-install).
+
+# info.FetchingArtifacts
+
+Fetching available artifacts...
+
+# info.NoArtifactsAvailable
+
+No artifacts available from the configured source.
+
+# info.AllArtifactsInstalled
+
+All available artifacts are already installed.
+
+# info.AvailableArtifacts
+
+Available artifacts to install:
+
+# info.InstallingArtifacts
+
+Installing artifacts...
+
+# info.InstallSuccess
+
+Successfully installed %s artifact(s):
+
+# info.InstallCancelled
+
+Installation cancelled.
+
+# prompt.ConfirmTool
+
+Use %s as the active AI tool
+
+# prompt.ConfirmInstall
+
+Install %s artifact(s)
+
+# warning.InstallFailed
+
+Failed to install %s artifact(s):
+
+# error.NoToolsDetected
+
+No AI tools detected in this project.
+
+# error.NoToolsDetectedActions
+
+Initialize an AI tool first (e.g., create .github/copilot-instructions.md for Copilot or .claude/ directory for Claude), or specify a tool with --tool flag.
+
+# error.NoSourceConfigured
+
+No source repository configured.
+
+# error.NoSourceConfiguredActions
+
+Add a source with 'sf aidev source add owner/repo' or specify with --source flag.
+
+# error.SourceAddFailed
+
+Failed to add source %s: %s

--- a/src/commands/aidev/init.ts
+++ b/src/commands/aidev/init.ts
@@ -1,0 +1,262 @@
+/*
+ * Copyright (c) 2024, Yury Bondarau
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ */
+
+import { SfCommand, Flags } from '@salesforce/sf-plugins-core';
+import { Messages, SfError } from '@salesforce/core';
+import { ArtifactService, type InstallResult, type AvailableArtifact } from '../../services/artifactService.js';
+import { SourceService } from '../../services/sourceService.js';
+import { AiDevConfig } from '../../config/aiDevConfig.js';
+import { DetectorRegistry } from '../../detectors/registry.js';
+
+Messages.importMessagesDirectoryFromMetaUrl(import.meta.url);
+const messages = Messages.loadMessages('ai-dev', 'aidev.init');
+
+export type InitResult = {
+  tool: string;
+  source: string;
+  detectedTools: string[];
+  installedArtifacts: InstallResult[];
+};
+
+type InitFlags = {
+  tool?: string;
+  source?: string;
+  'no-install': boolean;
+  'no-prompt': boolean;
+};
+
+export default class Init extends SfCommand<InitResult> {
+  public static readonly summary = messages.getMessage('summary');
+  public static readonly description = messages.getMessage('description');
+  public static readonly examples = messages.getMessages('examples');
+  public static readonly enableJsonFlag = true;
+
+  public static readonly flags = {
+    tool: Flags.string({
+      char: 't',
+      summary: messages.getMessage('flags.tool.summary'),
+      options: ['copilot', 'claude', 'cursor', 'windsurf', 'gemini', 'codex'],
+    }),
+    source: Flags.string({
+      char: 's',
+      summary: messages.getMessage('flags.source.summary'),
+    }),
+    'no-install': Flags.boolean({
+      summary: messages.getMessage('flags.no-install.summary'),
+      default: false,
+    }),
+    'no-prompt': Flags.boolean({
+      summary: messages.getMessage('flags.no-prompt.summary'),
+      default: false,
+    }),
+  };
+
+  public async run(): Promise<InitResult> {
+    const { flags } = await this.parse(Init);
+    const projectPath = process.cwd();
+
+    const selectedTool = await this.selectTool(flags as InitFlags, projectPath);
+    const detectedTools = await DetectorRegistry.detectAll(projectPath);
+
+    const config = await AiDevConfig.create({ isGlobal: false });
+    const artifactService = new ArtifactService(config, projectPath);
+    const sourceService = new SourceService(config);
+
+    await artifactService.setActiveTool(selectedTool);
+    this.log(messages.getMessage('info.ToolConfigured', [selectedTool]));
+
+    const sourceRepo = await this.configureSource(flags as InitFlags, sourceService);
+
+    const installedArtifacts = await this.handleArtifactInstallation(flags as InitFlags, artifactService, sourceRepo);
+
+    return {
+      tool: selectedTool,
+      source: sourceRepo,
+      detectedTools,
+      installedArtifacts,
+    };
+  }
+
+  private async selectTool(flags: InitFlags, projectPath: string): Promise<string> {
+    if (flags.tool) {
+      return flags.tool;
+    }
+
+    this.spinner.start(messages.getMessage('info.DetectingTools'));
+    const detectedTools = await DetectorRegistry.detectAll(projectPath);
+    this.spinner.stop();
+
+    if (detectedTools.length === 0) {
+      throw new SfError(messages.getMessage('error.NoToolsDetected'), 'NoToolsDetected', [
+        messages.getMessage('error.NoToolsDetectedActions'),
+      ]);
+    }
+
+    if (detectedTools.length === 1) {
+      this.log(messages.getMessage('info.SingleToolDetected', [detectedTools[0]]));
+      return detectedTools[0];
+    }
+
+    return this.selectFromMultipleTools(detectedTools, flags['no-prompt']);
+  }
+
+  private async selectFromMultipleTools(detectedTools: string[], noPrompt: boolean): Promise<string> {
+    this.log(messages.getMessage('info.MultipleToolsDetected', [detectedTools.join(', ')]));
+    const preferredTool = detectedTools.includes('copilot') ? 'copilot' : detectedTools[0];
+
+    if (noPrompt) {
+      this.log(messages.getMessage('info.AutoSelectedTool', [preferredTool]));
+      return preferredTool;
+    }
+
+    const confirmed = await this.confirm({
+      message: messages.getMessage('prompt.ConfirmTool', [preferredTool]),
+    });
+
+    if (confirmed) {
+      return preferredTool;
+    }
+
+    return detectedTools.find((t) => t !== preferredTool) ?? preferredTool;
+  }
+
+  private async configureSource(flags: InitFlags, sourceService: SourceService): Promise<string> {
+    let sourceRepo: string;
+
+    if (flags.source) {
+      sourceRepo = flags.source;
+    } else {
+      const defaultSource = sourceService.getDefault();
+      if (!defaultSource) {
+        throw new SfError(messages.getMessage('error.NoSourceConfigured'), 'NoSourceConfigured', [
+          messages.getMessage('error.NoSourceConfiguredActions'),
+        ]);
+      }
+      sourceRepo = defaultSource.repo;
+      this.log(messages.getMessage('info.UsingDefaultSource', [sourceRepo]));
+    }
+
+    if (!sourceService.has(sourceRepo)) {
+      this.spinner.start(messages.getMessage('info.AddingSource', [sourceRepo]));
+      const addResult = await sourceService.add(sourceRepo);
+      this.spinner.stop();
+
+      if (!addResult.success) {
+        const errorMsg = addResult.error ?? 'Unknown error';
+        throw new SfError(messages.getMessage('error.SourceAddFailed', [sourceRepo, errorMsg]), 'SourceAddFailed');
+      }
+    }
+
+    return sourceRepo;
+  }
+
+  private async handleArtifactInstallation(
+    flags: InitFlags,
+    artifactService: ArtifactService,
+    sourceRepo: string
+  ): Promise<InstallResult[]> {
+    if (flags['no-install']) {
+      this.log(messages.getMessage('info.SkippingInstall'));
+      return [];
+    }
+
+    const toInstall = await this.getArtifactsToInstall(artifactService, sourceRepo);
+    if (toInstall.length === 0) {
+      return [];
+    }
+
+    const shouldInstall = await this.confirmInstallation(toInstall, flags['no-prompt']);
+    if (!shouldInstall) {
+      return [];
+    }
+
+    return this.installArtifacts(artifactService, toInstall, sourceRepo);
+  }
+
+  private async getArtifactsToInstall(
+    artifactService: ArtifactService,
+    sourceRepo: string
+  ): Promise<AvailableArtifact[]> {
+    this.spinner.start(messages.getMessage('info.FetchingArtifacts'));
+    const available = await artifactService.listAvailable({ source: sourceRepo });
+    this.spinner.stop();
+
+    if (available.length === 0) {
+      this.log(messages.getMessage('info.NoArtifactsAvailable'));
+      return [];
+    }
+
+    const toInstall = available.filter((a) => !a.installed);
+
+    if (toInstall.length === 0) {
+      this.log(messages.getMessage('info.AllArtifactsInstalled'));
+    }
+
+    return toInstall;
+  }
+
+  private async confirmInstallation(toInstall: AvailableArtifact[], noPrompt: boolean): Promise<boolean> {
+    if (noPrompt) {
+      return true;
+    }
+
+    this.log(messages.getMessage('info.AvailableArtifacts'));
+    for (const artifact of toInstall) {
+      this.log(`  - ${artifact.type}: ${artifact.name}`);
+    }
+
+    const confirmed = await this.confirm({
+      message: messages.getMessage('prompt.ConfirmInstall', [toInstall.length.toString()]),
+    });
+
+    if (!confirmed) {
+      this.log(messages.getMessage('info.InstallCancelled'));
+    }
+
+    return confirmed;
+  }
+
+  private async installArtifacts(
+    artifactService: ArtifactService,
+    toInstall: AvailableArtifact[],
+    sourceRepo: string
+  ): Promise<InstallResult[]> {
+    this.spinner.start(messages.getMessage('info.InstallingArtifacts'));
+
+    const installPromises = toInstall.map((artifact) =>
+      artifactService.install(artifact.name, {
+        type: artifact.type,
+        source: sourceRepo,
+      })
+    );
+
+    const installedArtifacts = await Promise.all(installPromises);
+    this.spinner.stop();
+
+    this.reportInstallResults(installedArtifacts);
+
+    return installedArtifacts;
+  }
+
+  private reportInstallResults(installedArtifacts: InstallResult[]): void {
+    const successful = installedArtifacts.filter((r) => r.success);
+    const failed = installedArtifacts.filter((r) => !r.success);
+
+    if (successful.length > 0) {
+      this.log(messages.getMessage('info.InstallSuccess', [successful.length.toString()]));
+      for (const result of successful) {
+        this.log(`  - ${result.artifact} -> ${result.installedPath}`);
+      }
+    }
+
+    if (failed.length > 0) {
+      this.warn(messages.getMessage('warning.InstallFailed', [failed.length.toString()]));
+      for (const result of failed) {
+        this.log(`  - ${result.artifact}: ${result.error ?? 'Unknown error'}`);
+      }
+    }
+  }
+}

--- a/test/commands/aidev/init.test.ts
+++ b/test/commands/aidev/init.test.ts
@@ -1,0 +1,309 @@
+/*
+ * Copyright (c) 2024, Yury Bondarau
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ */
+
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { Config } from '@oclif/core';
+import { SfCommand } from '@salesforce/sf-plugins-core';
+import Init from '../../../src/commands/aidev/init.js';
+import { ArtifactService } from '../../../src/services/artifactService.js';
+import { SourceService } from '../../../src/services/sourceService.js';
+import { AiDevConfig } from '../../../src/config/aiDevConfig.js';
+import { DetectorRegistry } from '../../../src/detectors/registry.js';
+import type { AvailableArtifact, InstallResult } from '../../../src/services/artifactService.js';
+
+describe('aidev init', () => {
+  let sandbox: sinon.SinonSandbox;
+  let detectAllStub: sinon.SinonStub;
+  let setActiveToolStub: sinon.SinonStub;
+  let listAvailableStub: sinon.SinonStub;
+  let installStub: sinon.SinonStub;
+  let getDefaultStub: sinon.SinonStub;
+  let hasSourceStub: sinon.SinonStub;
+  let addSourceStub: sinon.SinonStub;
+  let confirmStub: sinon.SinonStub;
+  let oclifConfig: Config;
+
+  const availableArtifacts: AvailableArtifact[] = [
+    { name: 'skill-1', type: 'skill', source: 'owner/repo', installed: false },
+    { name: 'agent-1', type: 'agent', source: 'owner/repo', installed: false },
+  ];
+
+  const installSuccess: InstallResult = {
+    success: true,
+    artifact: 'skill-1',
+    type: 'skill',
+    tool: 'copilot',
+    installedPath: '.github/copilot-skills/skill-1.md',
+  };
+
+  before(async () => {
+    oclifConfig = await Config.load({ root: process.cwd() });
+  });
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+    sandbox.stub(AiDevConfig, 'create').resolves({} as AiDevConfig);
+    detectAllStub = sandbox.stub(DetectorRegistry, 'detectAll');
+    setActiveToolStub = sandbox.stub(ArtifactService.prototype, 'setActiveTool').resolves();
+    listAvailableStub = sandbox.stub(ArtifactService.prototype, 'listAvailable');
+    installStub = sandbox.stub(ArtifactService.prototype, 'install');
+    getDefaultStub = sandbox.stub(SourceService.prototype, 'getDefault');
+    hasSourceStub = sandbox.stub(SourceService.prototype, 'has');
+    addSourceStub = sandbox.stub(SourceService.prototype, 'add');
+    confirmStub = sandbox.stub(SfCommand.prototype, 'confirm');
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  describe('tool detection', () => {
+    it('uses single detected tool automatically', async () => {
+      detectAllStub.resolves(['copilot']);
+      getDefaultStub.returns({ repo: 'owner/repo' });
+      hasSourceStub.returns(true);
+      listAvailableStub.resolves([]);
+
+      const result = await Init.run(['--no-prompt'], oclifConfig);
+
+      expect(result.tool).to.equal('copilot');
+      expect(result.detectedTools).to.deep.equal(['copilot']);
+      expect(setActiveToolStub.calledWith('copilot')).to.be.true;
+    });
+
+    it('uses provided --tool flag over detection', async () => {
+      detectAllStub.resolves(['copilot']);
+      getDefaultStub.returns({ repo: 'owner/repo' });
+      hasSourceStub.returns(true);
+      listAvailableStub.resolves([]);
+
+      const result = await Init.run(['--tool', 'claude', '--no-prompt'], oclifConfig);
+
+      expect(result.tool).to.equal('claude');
+      expect(setActiveToolStub.calledWith('claude')).to.be.true;
+    });
+
+    it('throws error when no tools detected and no --tool flag', async () => {
+      detectAllStub.resolves([]);
+
+      const cmd = new Init([], oclifConfig);
+      try {
+        await cmd.run();
+        expect.fail('Should have thrown SfError');
+      } catch (error) {
+        expect(error).to.be.instanceOf(Error);
+        expect((error as Error).message).to.include('No AI tools detected');
+      }
+    });
+
+    it('auto-selects copilot when multiple tools detected with --no-prompt', async () => {
+      detectAllStub.resolves(['claude', 'copilot']);
+      getDefaultStub.returns({ repo: 'owner/repo' });
+      hasSourceStub.returns(true);
+      listAvailableStub.resolves([]);
+
+      const result = await Init.run(['--no-prompt'], oclifConfig);
+
+      expect(result.tool).to.equal('copilot');
+    });
+
+    it('prompts for tool confirmation when multiple detected', async () => {
+      detectAllStub.resolves(['claude', 'copilot']);
+      confirmStub.resolves(true);
+      getDefaultStub.returns({ repo: 'owner/repo' });
+      hasSourceStub.returns(true);
+      listAvailableStub.resolves([]);
+
+      const result = await Init.run([], oclifConfig);
+
+      expect(result.tool).to.equal('copilot');
+      expect(confirmStub.called).to.be.true;
+    });
+
+    it('selects alternate tool when user denies preferred', async () => {
+      detectAllStub.resolves(['claude', 'copilot']);
+      confirmStub.resolves(false);
+      getDefaultStub.returns({ repo: 'owner/repo' });
+      hasSourceStub.returns(true);
+      listAvailableStub.resolves([]);
+
+      const result = await Init.run([], oclifConfig);
+
+      expect(result.tool).to.equal('claude');
+    });
+  });
+
+  describe('source configuration', () => {
+    it('uses provided --source flag', async () => {
+      detectAllStub.resolves(['copilot']);
+      hasSourceStub.returns(false);
+      addSourceStub.resolves({ success: true });
+      listAvailableStub.resolves([]);
+
+      const result = await Init.run(['--source', 'custom/repo', '--no-prompt'], oclifConfig);
+
+      expect(result.source).to.equal('custom/repo');
+    });
+
+    it('uses default source when available', async () => {
+      detectAllStub.resolves(['copilot']);
+      getDefaultStub.returns({ repo: 'owner/repo' });
+      hasSourceStub.returns(true);
+      listAvailableStub.resolves([]);
+
+      const result = await Init.run(['--no-prompt'], oclifConfig);
+
+      expect(result.source).to.equal('owner/repo');
+    });
+
+    it('throws error when no source available', async () => {
+      detectAllStub.resolves(['copilot']);
+      getDefaultStub.returns(undefined);
+
+      const cmd = new Init(['--no-prompt'], oclifConfig);
+      try {
+        await cmd.run();
+        expect.fail('Should have thrown SfError');
+      } catch (error) {
+        expect(error).to.be.instanceOf(Error);
+        expect((error as Error).message).to.include('No source repository configured');
+      }
+    });
+
+    it('adds new source when not already configured', async () => {
+      detectAllStub.resolves(['copilot']);
+      hasSourceStub.returns(false);
+      addSourceStub.resolves({ success: true });
+      listAvailableStub.resolves([]);
+
+      await Init.run(['--source', 'new/repo', '--no-prompt'], oclifConfig);
+
+      expect(addSourceStub.calledWith('new/repo')).to.be.true;
+    });
+
+    it('throws error when source add fails', async () => {
+      detectAllStub.resolves(['copilot']);
+      hasSourceStub.returns(false);
+      addSourceStub.resolves({ success: false, error: 'Network error' });
+
+      const cmd = new Init(['--source', 'bad/repo', '--no-prompt'], oclifConfig);
+      try {
+        await cmd.run();
+        expect.fail('Should have thrown SfError');
+      } catch (error) {
+        expect(error).to.be.instanceOf(Error);
+        expect((error as Error).message).to.include('Failed to add source');
+      }
+    });
+  });
+
+  describe('artifact installation', () => {
+    beforeEach(() => {
+      detectAllStub.resolves(['copilot']);
+      getDefaultStub.returns({ repo: 'owner/repo' });
+      hasSourceStub.returns(true);
+    });
+
+    it('installs available artifacts with --no-prompt', async () => {
+      listAvailableStub.resolves(availableArtifacts);
+      installStub.resolves(installSuccess);
+
+      const result = await Init.run(['--no-prompt'], oclifConfig);
+
+      expect(installStub.callCount).to.equal(2);
+      expect(result.installedArtifacts).to.have.lengthOf(2);
+    });
+
+    it('skips installation with --no-install flag', async () => {
+      const result = await Init.run(['--no-install', '--no-prompt'], oclifConfig);
+
+      expect(listAvailableStub.called).to.be.false;
+      expect(installStub.called).to.be.false;
+      expect(result.installedArtifacts).to.have.lengthOf(0);
+    });
+
+    it('skips already installed artifacts', async () => {
+      listAvailableStub.resolves([{ ...availableArtifacts[0], installed: true }, availableArtifacts[1]]);
+      installStub.resolves(installSuccess);
+
+      const result = await Init.run(['--no-prompt'], oclifConfig);
+
+      expect(installStub.callCount).to.equal(1);
+      expect(result.installedArtifacts).to.have.lengthOf(1);
+    });
+
+    it('reports no artifacts available', async () => {
+      listAvailableStub.resolves([]);
+
+      const result = await Init.run(['--no-prompt'], oclifConfig);
+
+      expect(installStub.called).to.be.false;
+      expect(result.installedArtifacts).to.have.lengthOf(0);
+    });
+
+    it('reports all artifacts already installed', async () => {
+      listAvailableStub.resolves([{ ...availableArtifacts[0], installed: true }]);
+
+      await Init.run(['--no-prompt'], oclifConfig);
+
+      expect(installStub.called).to.be.false;
+    });
+
+    it('prompts for install confirmation', async () => {
+      listAvailableStub.resolves(availableArtifacts);
+      confirmStub.onFirstCall().resolves(true); // tool confirmation not called for single tool
+      confirmStub.resolves(true);
+      installStub.resolves(installSuccess);
+
+      await Init.run([], oclifConfig);
+
+      expect(confirmStub.called).to.be.true;
+    });
+
+    it('cancels installation when user denies', async () => {
+      listAvailableStub.resolves(availableArtifacts);
+      confirmStub.resolves(false);
+
+      const result = await Init.run([], oclifConfig);
+
+      expect(installStub.called).to.be.false;
+      expect(result.installedArtifacts).to.have.lengthOf(0);
+    });
+
+    it('handles mixed install results', async () => {
+      listAvailableStub.resolves(availableArtifacts);
+      installStub.onFirstCall().resolves(installSuccess);
+      installStub.onSecondCall().resolves({
+        ...installSuccess,
+        success: false,
+        error: 'Install failed',
+      });
+
+      const result = await Init.run(['--no-prompt'], oclifConfig);
+
+      expect(result.installedArtifacts).to.have.lengthOf(2);
+      expect(result.installedArtifacts.filter((r) => r.success)).to.have.lengthOf(1);
+      expect(result.installedArtifacts.filter((r) => !r.success)).to.have.lengthOf(1);
+    });
+  });
+
+  describe('command metadata', () => {
+    it('has required static properties', () => {
+      expect(Init.summary).to.be.a('string').and.not.be.empty;
+      expect(Init.description).to.be.a('string').and.not.be.empty;
+      expect(Init.examples).to.be.an('array').and.have.length.greaterThan(0);
+      expect(Init.enableJsonFlag).to.be.true;
+    });
+
+    it('has correct flag definitions', () => {
+      expect(Init.flags).to.have.property('tool');
+      expect(Init.flags).to.have.property('source');
+      expect(Init.flags).to.have.property('no-install');
+      expect(Init.flags).to.have.property('no-prompt');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Implement `aidev init` command for interactive AI development setup
- Detects AI tools in project (Copilot, Claude, Cursor, Windsurf, Gemini, Codex)
- Configures active tool and source repository
- Installs available artifacts from configured sources
- Supports `--tool`, `--source`, `--no-install`, `--no-prompt` flags for scripting

## Related Issue

Closes #21

## Test plan

- [x] `yarn build` passes
- [x] `yarn test` passes with all tests passing
- [x] `yarn lint` passes with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)