### PR TITLE
feat(commands): implement aidev remove prompt command

### DIFF
--- a/messages/aidev.remove.prompt.md
+++ b/messages/aidev.remove.prompt.md
@@ -1,0 +1,45 @@
+# summary
+
+Remove an installed prompt.
+
+# description
+
+Remove a previously installed prompt from your project. The prompt file will be deleted and unregistered from the ai-dev configuration. By default, a confirmation prompt is shown before removal.
+
+# flags.name.summary
+
+Name of the prompt to remove.
+
+# flags.no-prompt.summary
+
+Skip the confirmation prompt.
+
+# examples
+
+- Remove a prompt named "my-prompt":
+
+  <%= config.bin %> <%= command.id %> --name my-prompt
+
+- Remove without confirmation:
+
+  <%= config.bin %> <%= command.id %> --name my-prompt --no-prompt
+
+# prompt.ConfirmRemove
+
+Are you sure you want to remove prompt "%s"?
+
+# error.NotInstalled
+
+Prompt "%s" is not installed.
+
+# error.RemoveFailed
+
+Failed to remove prompt "%s": %s
+
+# info.PromptRemoved
+
+Successfully removed prompt "%s".
+
+# info.Cancelled
+
+Removal cancelled.

--- a/src/commands/aidev/remove/prompt.ts
+++ b/src/commands/aidev/remove/prompt.ts
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2024, Yury Bondarau
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ */
+
+import { SfCommand, Flags } from '@salesforce/sf-plugins-core';
+import { Messages, SfError } from '@salesforce/core';
+import { ArtifactService } from '../../../services/artifactService.js';
+import { AiDevConfig } from '../../../config/aiDevConfig.js';
+
+Messages.importMessagesDirectoryFromMetaUrl(import.meta.url);
+const messages = Messages.loadMessages('ai-dev', 'aidev.remove.prompt');
+
+export interface RemovePromptResult {
+  success: boolean;
+  name: string;
+  error?: string;
+}
+
+export default class RemovePrompt extends SfCommand<RemovePromptResult> {
+  public static readonly summary = messages.getMessage('summary');
+  public static readonly description = messages.getMessage('description');
+  public static readonly examples = messages.getMessages('examples');
+  public static readonly enableJsonFlag = true;
+
+  public static readonly flags = {
+    name: Flags.string({
+      char: 'n',
+      summary: messages.getMessage('flags.name.summary'),
+      required: true,
+    }),
+    'no-prompt': Flags.boolean({
+      summary: messages.getMessage('flags.no-prompt.summary'),
+      default: false,
+    }),
+  };
+
+  public async run(): Promise<RemovePromptResult> {
+    const { flags } = await this.parse(RemovePrompt);
+
+    const config = await AiDevConfig.create({ isGlobal: false });
+    const service = new ArtifactService(config, process.cwd());
+
+    // Check if prompt is installed
+    if (!service.isInstalled(flags.name, 'prompt')) {
+      throw new SfError(messages.getMessage('error.NotInstalled', [flags.name]), 'NotInstalledError');
+    }
+
+    // Confirm removal unless --no-prompt is specified
+    if (!flags['no-prompt']) {
+      const confirmed = await this.confirm({
+        message: messages.getMessage('prompt.ConfirmRemove', [flags.name]),
+      });
+      if (!confirmed) {
+        this.log(messages.getMessage('info.Cancelled'));
+        return { success: false, name: flags.name, error: 'User cancelled removal' };
+      }
+    }
+
+    const result = await service.uninstall(flags.name, { type: 'prompt' });
+
+    if (!result.success) {
+      throw new SfError(
+        messages.getMessage('error.RemoveFailed', [flags.name, result.error ?? 'Unknown error']),
+        'RemoveError'
+      );
+    }
+
+    this.log(messages.getMessage('info.PromptRemoved', [flags.name]));
+    return { success: true, name: flags.name };
+  }
+}

--- a/test/commands/aidev/remove/prompt.test.ts
+++ b/test/commands/aidev/remove/prompt.test.ts
@@ -1,0 +1,152 @@
+/*
+ * Copyright (c) 2024, Yury Bondarau
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ */
+
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { Config } from '@oclif/core';
+import { SfCommand } from '@salesforce/sf-plugins-core';
+import RemovePrompt from '../../../../src/commands/aidev/remove/prompt.js';
+import { ArtifactService } from '../../../../src/services/artifactService.js';
+import { AiDevConfig } from '../../../../src/config/aiDevConfig.js';
+
+describe('aidev remove prompt', () => {
+  let sandbox: sinon.SinonSandbox;
+  let isInstalledStub: sinon.SinonStub;
+  let uninstallStub: sinon.SinonStub;
+  let confirmStub: sinon.SinonStub;
+  let oclifConfig: Config;
+
+  before(async () => {
+    oclifConfig = await Config.load({ root: process.cwd() });
+  });
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+    sandbox.stub(AiDevConfig, 'create').resolves({} as AiDevConfig);
+    isInstalledStub = sandbox.stub(ArtifactService.prototype, 'isInstalled');
+    uninstallStub = sandbox.stub(ArtifactService.prototype, 'uninstall');
+    confirmStub = sandbox.stub(SfCommand.prototype, 'confirm');
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  describe('successful removal', () => {
+    it('removes a prompt with confirmation', async () => {
+      isInstalledStub.returns(true);
+      confirmStub.resolves(true);
+      uninstallStub.resolves({ success: true });
+
+      const result = await RemovePrompt.run(['--name', 'my-prompt'], oclifConfig);
+
+      expect(result.success).to.be.true;
+      expect(result.name).to.equal('my-prompt');
+      expect(confirmStub.calledOnce).to.be.true;
+      expect(uninstallStub.calledOnce).to.be.true;
+      expect(uninstallStub.firstCall.args[0]).to.equal('my-prompt');
+      expect(uninstallStub.firstCall.args[1]).to.deep.equal({ type: 'prompt' });
+    });
+
+    it('removes a prompt with --no-prompt flag', async () => {
+      isInstalledStub.returns(true);
+      uninstallStub.resolves({ success: true });
+
+      const result = await RemovePrompt.run(['--name', 'my-prompt', '--no-prompt'], oclifConfig);
+
+      expect(result.success).to.be.true;
+      expect(result.name).to.equal('my-prompt');
+      expect(confirmStub.called).to.be.false;
+      expect(uninstallStub.calledOnce).to.be.true;
+    });
+
+    it('removes a prompt using short flag -n', async () => {
+      isInstalledStub.returns(true);
+      confirmStub.resolves(true);
+      uninstallStub.resolves({ success: true });
+
+      const result = await RemovePrompt.run(['-n', 'my-prompt'], oclifConfig);
+
+      expect(result.success).to.be.true;
+      expect(isInstalledStub.firstCall.args[0]).to.equal('my-prompt');
+    });
+  });
+
+  describe('user cancellation', () => {
+    it('returns cancelled result when user denies confirmation', async () => {
+      isInstalledStub.returns(true);
+      confirmStub.resolves(false);
+
+      const result = await RemovePrompt.run(['--name', 'my-prompt'], oclifConfig);
+
+      expect(result.success).to.be.false;
+      expect(result.name).to.equal('my-prompt');
+      expect(result.error).to.equal('User cancelled removal');
+      expect(uninstallStub.called).to.be.false;
+    });
+  });
+
+  describe('error handling', () => {
+    it('throws SfError when prompt is not installed', async () => {
+      isInstalledStub.returns(false);
+
+      const cmd = new RemovePrompt(['--name', 'not-installed'], oclifConfig);
+      try {
+        await cmd.run();
+        expect.fail('Should have thrown SfError');
+      } catch (error) {
+        expect(error).to.be.instanceOf(Error);
+        expect((error as Error).message).to.include('not-installed');
+        expect((error as Error).message).to.include('not installed');
+      }
+    });
+
+    it('throws SfError when uninstall fails', async () => {
+      isInstalledStub.returns(true);
+      confirmStub.resolves(true);
+      uninstallStub.resolves({ success: false, error: 'File deletion failed' });
+
+      const cmd = new RemovePrompt(['--name', 'my-prompt'], oclifConfig);
+      try {
+        await cmd.run();
+        expect.fail('Should have thrown SfError');
+      } catch (error) {
+        expect(error).to.be.instanceOf(Error);
+        expect((error as Error).message).to.include('my-prompt');
+        expect((error as Error).message).to.include('File deletion failed');
+      }
+    });
+
+    it('throws SfError with generic message when error is undefined', async () => {
+      isInstalledStub.returns(true);
+      confirmStub.resolves(true);
+      uninstallStub.resolves({ success: false });
+
+      const cmd = new RemovePrompt(['--name', 'my-prompt'], oclifConfig);
+      try {
+        await cmd.run();
+        expect.fail('Should have thrown SfError');
+      } catch (error) {
+        expect(error).to.be.instanceOf(Error);
+        expect((error as Error).message).to.include('Unknown error');
+      }
+    });
+  });
+
+  describe('command metadata', () => {
+    it('has required static properties', () => {
+      expect(RemovePrompt.summary).to.be.a('string').and.not.be.empty;
+      expect(RemovePrompt.description).to.be.a('string').and.not.be.empty;
+      expect(RemovePrompt.examples).to.be.an('array').and.have.length.greaterThan(0);
+      expect(RemovePrompt.enableJsonFlag).to.be.true;
+    });
+
+    it('has correct flag definitions', () => {
+      expect(RemovePrompt.flags).to.have.property('name');
+      expect(RemovePrompt.flags).to.have.property('no-prompt');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Adds the missing `aidev remove prompt` command for symmetric add/remove support across all artifact types (skill, agent, prompt)
- Follows exact pattern from `remove/skill.ts` and `remove/agent.ts`

## Changes
- `src/commands/aidev/remove/prompt.ts` — New command implementation
- `messages/aidev.remove.prompt.md` — Help messages
- `test/commands/aidev/remove/prompt.test.ts` — 9 unit tests

## Test plan
- [x] All 9 new tests pass
- [x] TypeScript compiles cleanly
- [x] Lint passes

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)