### PR TITLE
fix: standardize --no-prompt flag descriptions

### DIFF
--- a/messages/aidev.init.md
+++ b/messages/aidev.init.md
@@ -20,7 +20,7 @@ Skip artifact installation, only configure tool and source.
 
 # flags.no-prompt.summary
 
-Skip confirmation prompts (for scripting).
+Skip the confirmation prompt.
 
 # examples
 

--- a/messages/aidev.source.remove.md
+++ b/messages/aidev.source.remove.md
@@ -12,7 +12,7 @@ GitHub repository in owner/repo format to remove.
 
 # flags.no-prompt.summary
 
-Skip confirmation prompt.
+Skip the confirmation prompt.
 
 # examples
 


### PR DESCRIPTION
## Summary
- Standardizes `--no-prompt` flag summary text across all commands to "Skip the confirmation prompt."

## Changes
- `messages/aidev.init.md` — Changed from "Skip confirmation prompts (for scripting)."
- `messages/aidev.source.remove.md` — Changed from "Skip confirmation prompt." (was missing "the")

## Test plan
- [x] All existing tests pass
- [x] No functional changes, only help text

Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)