### PR TITLE
fix: standardize SfError name suffixes in init command

### DIFF
--- a/src/commands/aidev/init.ts
+++ b/src/commands/aidev/init.ts
@@ -90,7 +90,7 @@ export default class Init extends SfCommand<InitResult> {
     this.spinner.stop();
 
     if (detectedTools.length === 0) {
-      throw new SfError(messages.getMessage('error.NoToolsDetected'), 'NoToolsDetected', [
+      throw new SfError(messages.getMessage('error.NoToolsDetected'), 'NoToolsDetectedError', [
         messages.getMessage('error.NoToolsDetectedActions'),
       ]);
     }
@@ -131,7 +131,7 @@ export default class Init extends SfCommand<InitResult> {
     } else {
       const defaultSource = sourceService.getDefault();
       if (!defaultSource) {
-        throw new SfError(messages.getMessage('error.NoSourceConfigured'), 'NoSourceConfigured', [
+        throw new SfError(messages.getMessage('error.NoSourceConfigured'), 'NoSourceConfiguredError', [
           messages.getMessage('error.NoSourceConfiguredActions'),
         ]);
       }
@@ -146,7 +146,7 @@ export default class Init extends SfCommand<InitResult> {
 
       if (!addResult.success) {
         const errorMsg = addResult.error ?? 'Unknown error';
-        throw new SfError(messages.getMessage('error.SourceAddFailed', [sourceRepo, errorMsg]), 'SourceAddFailed');
+        throw new SfError(messages.getMessage('error.SourceAddFailed', [sourceRepo, errorMsg]), 'SourceAddFailedError');
       }
     }
 


### PR DESCRIPTION
## Summary
- Adds consistent `Error` suffix to all SfError names in `init.ts`, matching the convention used in all other commands

## Changes
- `src/commands/aidev/init.ts`:
  - `NoToolsDetected` → `NoToolsDetectedError`
  - `NoSourceConfigured` → `NoSourceConfiguredError`
  - `SourceAddFailed` → `SourceAddFailedError`

## Test plan
- [x] All existing tests pass (tests check error messages, not error names)
- [x] TypeScript compiles cleanly

Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)