### PR TITLE
refactor: convert interface to type for result types

### DIFF
--- a/src/commands/aidev/list/artifacts.ts
+++ b/src/commands/aidev/list/artifacts.ts
@@ -14,7 +14,7 @@ import type { ArtifactType } from '../../../types/manifest.js';
 Messages.importMessagesDirectoryFromMetaUrl(import.meta.url);
 const messages = Messages.loadMessages('ai-dev', 'aidev.list.artifacts');
 
-export interface ListArtifactsResult {
+export type ListArtifactsResult = {
   installed: InstalledArtifact[];
   available: AvailableArtifact[];
 }

--- a/src/commands/aidev/remove/agent.ts
+++ b/src/commands/aidev/remove/agent.ts
@@ -12,7 +12,7 @@ import { AiDevConfig } from '../../../config/aiDevConfig.js';
 Messages.importMessagesDirectoryFromMetaUrl(import.meta.url);
 const messages = Messages.loadMessages('ai-dev', 'aidev.remove.agent');
 
-export interface RemoveAgentResult {
+export type RemoveAgentResult = {
   success: boolean;
   name: string;
   error?: string;

--- a/src/commands/aidev/remove/skill.ts
+++ b/src/commands/aidev/remove/skill.ts
@@ -12,7 +12,7 @@ import { AiDevConfig } from '../../../config/aiDevConfig.js';
 Messages.importMessagesDirectoryFromMetaUrl(import.meta.url);
 const messages = Messages.loadMessages('ai-dev', 'aidev.remove.skill');
 
-export interface RemoveSkillResult {
+export type RemoveSkillResult = {
   success: boolean;
   name: string;
   error?: string;


### PR DESCRIPTION
## Summary
- Converts 3 result type definitions from `interface` to `type` for consistency with all other commands

## Changes
- `src/commands/aidev/list/artifacts.ts` — `interface ListArtifactsResult` → `type ListArtifactsResult =`
- `src/commands/aidev/remove/agent.ts` — `interface RemoveAgentResult` → `type RemoveAgentResult =`
- `src/commands/aidev/remove/skill.ts` — `interface RemoveSkillResult` → `type RemoveSkillResult =`

## Test plan
- [x] All existing tests pass
- [x] TypeScript compiles cleanly
- [x] No functional changes

Closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)