### PR TITLE
chore: rename npm package from ai-dev to sf-aidev

### DIFF
--- a/PUBLISH_INSTRUCTIONS.md
+++ b/PUBLISH_INSTRUCTIONS.md
@@ -1,0 +1,133 @@
+# Publishing Guide for Salesforce CLI Plugins
+
+There are two distinct paths for publishing a Salesforce CLI plugin depending on your goal.
+
+---
+
+## Path 1: Publish as a Community/Third-Party Plugin
+
+This is the standard path for non-Salesforce plugins. No submission or approval process required.
+
+### Prerequisites
+
+- Node.js >= 18
+- An npm account ([npmjs.com](https://www.npmjs.com/)) — run `npm login` to authenticate
+- Your `package.json` is correctly configured (see below)
+
+### package.json Requirements
+
+The following fields must be set:
+
+```json
+{
+  "publishConfig": { "access": "public" },
+  "files": ["/lib", "/messages", "/oclif.manifest.json", "/oclif.lock"],
+  "exports": "./lib/index.js",
+  "keywords": ["sf-plugin", "sfdx-plugin"]
+}
+```
+
+- `publishConfig.access` — ensures the package is publicly accessible on npm
+- `files` — specifies which files are included in the published package
+- `exports` — entry point for ESM consumers
+- `keywords` — `sf-plugin` and `sfdx-plugin` make the plugin discoverable via `sf plugins discover`
+
+### Build Scripts
+
+The generated `prepack` and `postpack` scripts handle the build lifecycle automatically:
+
+| Script     | Description                                                                |
+| ---------- | -------------------------------------------------------------------------- |
+| `prepack`  | Runs `sf-prepack` — builds the project and generates `oclif.manifest.json` |
+| `postpack` | Runs `sf-clean` — removes generated artifacts after packing                |
+
+### Publishing
+
+```bash
+# 1. Bump the version (creates a git tag automatically)
+npm version patch   # or minor, or major
+
+# 2. Publish to npm (prepack runs automatically)
+npm publish
+
+# 3. Push the version tag to GitHub
+git push --follow-tags
+```
+
+### User Installation
+
+Once published, users install the plugin with:
+
+```bash
+sf plugins install sf-aidev
+```
+
+This pulls the package directly from the npm registry.
+
+### Discoverability
+
+Users can find third-party plugins via:
+
+```bash
+sf plugins discover
+```
+
+This command indexes npm packages tagged with `oclif-plugin` or `sf-plugin` keywords. Your plugin will appear automatically once published with the correct keywords.
+
+### CI/CD with GitHub Actions
+
+The Salesforce plugin generator (`sf dev generate plugin`) creates sample GitHub Actions workflows in `.github/workflows/*.yml` for:
+
+- **Testing** — run on every PR
+- **Releasing** — automated version bumps and npm publishing
+- **Publishing** — triggered on tag pushes or releases
+
+See the [Salesforce CLI GitHub Actions](https://github.com/salesforcecli) repos for reference implementations.
+
+---
+
+## Path 2: Become a Core/Official Salesforce CLI Plugin
+
+This path is for plugins maintained by the Salesforce CLI team under the `salesforcecli` GitHub organization.
+
+### Requirements
+
+| Requirement     | Details                                                                                                             |
+| --------------- | ------------------------------------------------------------------------------------------------------------------- |
+| **GitHub org**  | Repository must be hosted under [github.com/salesforcecli](https://github.com/salesforcecli)                        |
+| **npm scope**   | Published as `@salesforce/plugin-*` (e.g., `@salesforce/plugin-deploy-retrieve`)                                    |
+| **CLA**         | External contributors must sign a Contributor License Agreement at [cla.salesforce.com](https://cla.salesforce.com) |
+| **CI/CD**       | CircleCI with the `npm-release-management-orb` for automated releases                                               |
+| **Signing**     | Cryptographic signing via `@salesforce/plugin-trust` — prevents tampering with official packages                    |
+| **Quality bar** | 95%+ code coverage, conventional commits, full NUT test suite, documentation                                        |
+| **License**     | Apache 2.0                                                                                                          |
+
+### What It Means to Be a Core Plugin
+
+- The plugin is **bundled with every `sf` installation** — listed in the CLI's own `package.json` under `oclif.plugins`
+- Follows Salesforce's **weekly release cadence**
+- Verified via `sf plugins trust verify` before installation
+- Listed in `sf plugins --core` output
+
+### How to Initiate
+
+There is no public self-service submission form. The process requires:
+
+1. **Open a proposal** at [github.com/forcedotcom/cli/issues](https://github.com/forcedotcom/cli/issues) — this is where CLI feature requests and plugin proposals are tracked
+2. **Engage the Platform CLI team** — describe the plugin's value proposition, target audience, and how it fits into the Salesforce developer workflow
+3. **Meet the quality bar** — 95%+ coverage, conventional commits, full NUT test suite, and comprehensive documentation
+4. **Transfer the repository** to the `salesforcecli` GitHub organization upon acceptance
+
+### Realistic Path
+
+For community-developed plugins, Path 1 (npm publish) is the practical starting point. You can pursue Path 2 later once the plugin has traction and Salesforce expresses interest in official adoption.
+
+---
+
+## References
+
+- [Salesforce CLI Plugin Developer Guide](https://developer.salesforce.com/docs/platform/salesforce-cli-plugin/guide)
+- [oclif Releasing Guide](https://oclif.io/docs/releasing)
+- [Salesforce CLI Plugin Template](https://github.com/salesforcecli/plugin-template-sf)
+- [Salesforce CLI Issues & Proposals](https://github.com/forcedotcom/cli/issues)
+- [Salesforce CLI Status & Core Plugins](https://github.com/salesforcecli/status)

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
-# ai-dev
+# sf-aidev
 
-[![NPM](https://img.shields.io/npm/v/ai-dev.svg?label=ai-dev)](https://www.npmjs.com/package/ai-dev) [![Downloads/week](https://img.shields.io/npm/dw/ai-dev.svg)](https://npmjs.org/package/ai-dev) [![License](https://img.shields.io/badge/License-BSD%203--Clause-brightgreen.svg)](https://raw.githubusercontent.com/salesforcecli/ai-dev/main/LICENSE.txt)
+[![NPM](https://img.shields.io/npm/v/sf-aidev.svg?label=sf-aidev)](https://www.npmjs.com/package/sf-aidev) [![Downloads/week](https://img.shields.io/npm/dw/sf-aidev.svg)](https://npmjs.org/package/sf-aidev) [![License](https://img.shields.io/badge/License-BSD%203--Clause-brightgreen.svg)](https://raw.githubusercontent.com/salesforcecli/sf-aidev/main/LICENSE.txt)
 
 Salesforce CLI plugin that installs production-ready AI development tool configurations (skills, agents, prompts) from GitHub source repositories. Auto-detects which AI tool is in use, supports multiple tools, and provides unified management commands.
 
 ## Install
 
 ```bash
-sf plugins install ai-dev
+sf plugins install sf-aidev
 ```
 
 ## Quick Start
@@ -224,7 +224,7 @@ import { SfCommand, Flags } from '@salesforce/sf-plugins-core';
 import { Messages } from '@salesforce/core';
 
 Messages.importMessagesDirectoryFromMetaUrl(import.meta.url);
-const messages = Messages.loadMessages('ai-dev', 'aidev.{topic}.{name}');
+const messages = Messages.loadMessages('sf-aidev', 'aidev.{topic}.{name}');
 
 export type MyResult = {
   /* fields */

--- a/messages/aidev.remove.agent.md
+++ b/messages/aidev.remove.agent.md
@@ -4,7 +4,7 @@ Remove an installed agent.
 
 # description
 
-Remove a previously installed agent from your project. The agent files will be deleted and unregistered from the ai-dev configuration. By default, a confirmation prompt is shown before removal.
+Remove a previously installed agent from your project. The agent files will be deleted and unregistered from the sf-aidev configuration. By default, a confirmation prompt is shown before removal.
 
 # flags.name.summary
 

--- a/messages/aidev.remove.prompt.md
+++ b/messages/aidev.remove.prompt.md
@@ -4,7 +4,7 @@ Remove an installed prompt.
 
 # description
 
-Remove a previously installed prompt from your project. The prompt file will be deleted and unregistered from the ai-dev configuration. By default, a confirmation prompt is shown before removal.
+Remove a previously installed prompt from your project. The prompt file will be deleted and unregistered from the sf-aidev configuration. By default, a confirmation prompt is shown before removal.
 
 # flags.name.summary
 

--- a/messages/aidev.remove.skill.md
+++ b/messages/aidev.remove.skill.md
@@ -4,7 +4,7 @@ Remove an installed skill.
 
 # description
 
-Remove a previously installed skill from your project. The skill file will be deleted and unregistered from the ai-dev configuration. By default, a confirmation prompt is shown before removal.
+Remove a previously installed skill from your project. The skill file will be deleted and unregistered from the sf-aidev configuration. By default, a confirmation prompt is shown before removal.
 
 # flags.name.summary
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "ai-dev",
+  "name": "sf-aidev",
   "description": "Plugin that scaffold Prompt, Agent, Skills configuration for AI-supported development lifecycle for Salesforce Project. Supported formats are: Cloude Code, Codex, Gemini CLI, Github Copilot, Coursor",
   "version": "1.0.0",
   "dependencies": {

--- a/src/commands/aidev/add/agent.ts
+++ b/src/commands/aidev/add/agent.ts
@@ -10,7 +10,7 @@ import { ArtifactService, type InstallResult } from '../../../services/artifactS
 import { AiDevConfig } from '../../../config/aiDevConfig.js';
 
 Messages.importMessagesDirectoryFromMetaUrl(import.meta.url);
-const messages = Messages.loadMessages('ai-dev', 'aidev.add.agent');
+const messages = Messages.loadMessages('sf-aidev', 'aidev.add.agent');
 
 export type AddAgentResult = InstallResult;
 

--- a/src/commands/aidev/add/prompt.ts
+++ b/src/commands/aidev/add/prompt.ts
@@ -10,7 +10,7 @@ import { ArtifactService, type InstallResult } from '../../../services/artifactS
 import { AiDevConfig } from '../../../config/aiDevConfig.js';
 
 Messages.importMessagesDirectoryFromMetaUrl(import.meta.url);
-const messages = Messages.loadMessages('ai-dev', 'aidev.add.prompt');
+const messages = Messages.loadMessages('sf-aidev', 'aidev.add.prompt');
 
 export type AddPromptResult = InstallResult;
 

--- a/src/commands/aidev/add/skill.ts
+++ b/src/commands/aidev/add/skill.ts
@@ -10,7 +10,7 @@ import { ArtifactService, type InstallResult } from '../../../services/artifactS
 import { AiDevConfig } from '../../../config/aiDevConfig.js';
 
 Messages.importMessagesDirectoryFromMetaUrl(import.meta.url);
-const messages = Messages.loadMessages('ai-dev', 'aidev.add.skill');
+const messages = Messages.loadMessages('sf-aidev', 'aidev.add.skill');
 
 export type AddSkillResult = InstallResult;
 

--- a/src/commands/aidev/init.ts
+++ b/src/commands/aidev/init.ts
@@ -12,7 +12,7 @@ import { AiDevConfig } from '../../config/aiDevConfig.js';
 import { DetectorRegistry } from '../../detectors/registry.js';
 
 Messages.importMessagesDirectoryFromMetaUrl(import.meta.url);
-const messages = Messages.loadMessages('ai-dev', 'aidev.init');
+const messages = Messages.loadMessages('sf-aidev', 'aidev.init');
 
 export type InitResult = {
   tool: string;

--- a/src/commands/aidev/list/artifacts.ts
+++ b/src/commands/aidev/list/artifacts.ts
@@ -12,12 +12,12 @@ import type { InstalledArtifact } from '../../../types/config.js';
 import type { ArtifactType } from '../../../types/manifest.js';
 
 Messages.importMessagesDirectoryFromMetaUrl(import.meta.url);
-const messages = Messages.loadMessages('ai-dev', 'aidev.list.artifacts');
+const messages = Messages.loadMessages('sf-aidev', 'aidev.list.artifacts');
 
 export type ListArtifactsResult = {
   installed: InstalledArtifact[];
   available: AvailableArtifact[];
-}
+};
 
 export default class ListArtifacts extends SfCommand<ListArtifactsResult> {
   public static readonly summary = messages.getMessage('summary');

--- a/src/commands/aidev/remove/agent.ts
+++ b/src/commands/aidev/remove/agent.ts
@@ -10,13 +10,13 @@ import { ArtifactService } from '../../../services/artifactService.js';
 import { AiDevConfig } from '../../../config/aiDevConfig.js';
 
 Messages.importMessagesDirectoryFromMetaUrl(import.meta.url);
-const messages = Messages.loadMessages('ai-dev', 'aidev.remove.agent');
+const messages = Messages.loadMessages('sf-aidev', 'aidev.remove.agent');
 
 export type RemoveAgentResult = {
   success: boolean;
   name: string;
   error?: string;
-}
+};
 
 export default class RemoveAgent extends SfCommand<RemoveAgentResult> {
   public static readonly summary = messages.getMessage('summary');

--- a/src/commands/aidev/remove/prompt.ts
+++ b/src/commands/aidev/remove/prompt.ts
@@ -10,7 +10,7 @@ import { ArtifactService } from '../../../services/artifactService.js';
 import { AiDevConfig } from '../../../config/aiDevConfig.js';
 
 Messages.importMessagesDirectoryFromMetaUrl(import.meta.url);
-const messages = Messages.loadMessages('ai-dev', 'aidev.remove.prompt');
+const messages = Messages.loadMessages('sf-aidev', 'aidev.remove.prompt');
 
 export interface RemovePromptResult {
   success: boolean;

--- a/src/commands/aidev/remove/skill.ts
+++ b/src/commands/aidev/remove/skill.ts
@@ -10,13 +10,13 @@ import { ArtifactService } from '../../../services/artifactService.js';
 import { AiDevConfig } from '../../../config/aiDevConfig.js';
 
 Messages.importMessagesDirectoryFromMetaUrl(import.meta.url);
-const messages = Messages.loadMessages('ai-dev', 'aidev.remove.skill');
+const messages = Messages.loadMessages('sf-aidev', 'aidev.remove.skill');
 
 export type RemoveSkillResult = {
   success: boolean;
   name: string;
   error?: string;
-}
+};
 
 export default class RemoveSkill extends SfCommand<RemoveSkillResult> {
   public static readonly summary = messages.getMessage('summary');

--- a/src/commands/aidev/source/add.ts
+++ b/src/commands/aidev/source/add.ts
@@ -10,7 +10,7 @@ import { SourceService, type AddSourceResult } from '../../../services/sourceSer
 import { AiDevConfig } from '../../../config/aiDevConfig.js';
 
 Messages.importMessagesDirectoryFromMetaUrl(import.meta.url);
-const messages = Messages.loadMessages('ai-dev', 'aidev.source.add');
+const messages = Messages.loadMessages('sf-aidev', 'aidev.source.add');
 
 export type SourceAddResult = {
   repo: string;

--- a/src/commands/aidev/source/list.ts
+++ b/src/commands/aidev/source/list.ts
@@ -11,7 +11,7 @@ import { AiDevConfig } from '../../../config/aiDevConfig.js';
 import type { SourceConfig } from '../../../types/config.js';
 
 Messages.importMessagesDirectoryFromMetaUrl(import.meta.url);
-const messages = Messages.loadMessages('ai-dev', 'aidev.source.list');
+const messages = Messages.loadMessages('sf-aidev', 'aidev.source.list');
 
 export type SourceListItem = {
   repo: string;

--- a/src/commands/aidev/source/remove.ts
+++ b/src/commands/aidev/source/remove.ts
@@ -11,7 +11,7 @@ import { AiDevConfig } from '../../../config/aiDevConfig.js';
 import type { SourceConfig } from '../../../types/config.js';
 
 Messages.importMessagesDirectoryFromMetaUrl(import.meta.url);
-const messages = Messages.loadMessages('ai-dev', 'aidev.source.remove');
+const messages = Messages.loadMessages('sf-aidev', 'aidev.source.remove');
 
 export type SourceRemoveResult = {
   repo: string;

--- a/src/commands/aidev/source/set-default.ts
+++ b/src/commands/aidev/source/set-default.ts
@@ -11,7 +11,7 @@ import { AiDevConfig } from '../../../config/aiDevConfig.js';
 import type { SourceConfig } from '../../../types/config.js';
 
 Messages.importMessagesDirectoryFromMetaUrl(import.meta.url);
-const messages = Messages.loadMessages('ai-dev', 'aidev.source.set-default');
+const messages = Messages.loadMessages('sf-aidev', 'aidev.source.set-default');
 
 export type SetDefaultResult = {
   repo: string;

--- a/src/config/aiDevConfig.ts
+++ b/src/config/aiDevConfig.ts
@@ -9,7 +9,7 @@ import { ConfigFile } from '@salesforce/core';
 import { InstalledArtifact, SourceConfig } from '../types/config.js';
 
 /**
- * Configuration file for ai-dev plugin.
+ * Configuration file for sf-aidev plugin.
  * Stores source repositories, installed artifacts, and tool preferences.
  */
 export class AiDevConfig extends ConfigFile<ConfigFile.Options> {

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -37,7 +37,7 @@ export interface InstalledArtifact extends JsonMap {
 }
 
 /**
- * Schema for the ai-dev.json configuration file.
+ * Schema for the sf-aidev configuration file (ai-dev.json).
  */
 export interface AiDevConfigOptions extends JsonMap {
   /** Selected AI tool (e.g., 'copilot', 'claude') */


### PR DESCRIPTION
## Summary

- Rename npm package from `ai-dev` to `sf-aidev` since the `ai-dev` name is already taken on npm
- Update all `Messages.loadMessages()` calls across 12 command files
- Update README badges, npm links, and install command
- Update message file descriptions
- Add `PUBLISH_INSTRUCTIONS.md` with npm publishing guide for both community and official plugin paths

## Test plan

- [x] All 321 tests pass
- [x] Coverage thresholds met (95%+ across the board)
- [x] Lint passes (warnings only, no errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)