### PR TITLE
feat(ui): unify interactive UI controls across list/add/remove commands

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,4 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-yarn lint && yarn pretty-quick --staged
+yarn lint && npx lint-staged

--- a/.lintstagedrc.cjs
+++ b/.lintstagedrc.cjs
@@ -1,3 +1,3 @@
 module.exports = {
-  '**/*.{js,json,md}?(x)': () => 'npm run reformat',
+  '*.{ts,js,json}': 'prettier --write',
 };

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,1 +1,7 @@
-"@salesforce/prettier-config"
+{
+  "singleQuote": true,
+  "printWidth": 120,
+  "endOfLine": "auto",
+  "plugins": [],
+  "pluginSearchDirs": false
+}

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@salesforce/dev-scripts": "^10",
     "c8": "^10",
     "eslint-plugin-sf-plugin": "^1.20.33",
+    "lint-staged": "^16.4.0",
     "oclif": "^4.14.0",
     "ts-node": "^10.9.2",
     "tsx": "^4.21.0",

--- a/src/commands/aidev/add.ts
+++ b/src/commands/aidev/add.ts
@@ -10,6 +10,7 @@ import { checkbox, Separator } from '@inquirer/prompts';
 import { ArtifactService, type InstallResult, type AvailableArtifact } from '../../services/artifactService.js';
 import { AiDevConfig } from '../../config/aiDevConfig.js';
 import type { ArtifactType } from '../../types/manifest.js';
+import { CHECKBOX_THEME } from '../../ui/interactivePrompts.js';
 
 Messages.importMessagesDirectoryFromMetaUrl(import.meta.url);
 const messages = Messages.loadMessages('sf-aidev', 'aidev.add');
@@ -181,6 +182,7 @@ export default class Add extends SfCommand<AddResult> {
 
   /**
    * Prompt user with a multi-select checkbox.
+   * Returns empty array if user cancels (Escape/Ctrl+C).
    * Extracted as a protected method to allow stubbing in tests.
    */
   protected async promptCheckbox(
@@ -190,11 +192,20 @@ export default class Add extends SfCommand<AddResult> {
     // Use this.spinner to satisfy class-methods-use-this rule
     // The spinner is already stopped before this method is called
     void this.spinner;
-    return checkbox<AvailableArtifact>({
-      message,
-      choices,
-      pageSize: 15,
-    });
+    try {
+      return await checkbox<AvailableArtifact>({
+        message,
+        choices,
+        pageSize: 15,
+        theme: CHECKBOX_THEME,
+      });
+    } catch (error) {
+      // Handle user cancellation (Escape/Ctrl+C)
+      if (error instanceof Error && error.name === 'ExitPromptError') {
+        return [];
+      }
+      throw error;
+    }
   }
 
   /**

--- a/src/ui/interactivePrompts.ts
+++ b/src/ui/interactivePrompts.ts
@@ -9,10 +9,21 @@ import type { GroupedArtifacts, MergedArtifact } from '../services/localFileScan
 import type { ArtifactType } from '../types/manifest.js';
 
 /**
- * Checkbox characters for display.
+ * Square checkbox characters for consistent display.
  */
-const CHECKBOX_CHECKED = '\u2611'; // Checked box
-const CHECKBOX_UNCHECKED = '\u2610'; // Unchecked box
+const CHECKBOX_CHECKED = '\u2611'; // Checked box (filled square)
+const CHECKBOX_UNCHECKED = '\u2610'; // Unchecked box (empty square)
+
+/**
+ * Custom theme for @inquirer/checkbox prompt with square checkboxes.
+ */
+export const CHECKBOX_THEME = {
+  icon: {
+    checked: CHECKBOX_CHECKED,
+    unchecked: CHECKBOX_UNCHECKED,
+    cursor: '\u25B6', // Right-pointing triangle as cursor
+  },
+} as const;
 
 /**
  * Action types for the artifact action menu.
@@ -52,14 +63,27 @@ function isExitPromptError(error: unknown): boolean {
 
 /**
  * Format artifact display name with installation status indicator.
+ * Used for select prompts where we need to show status visually.
  *
  * @param artifact - The artifact to format.
- * @returns Formatted display string.
+ * @returns Formatted display string with checkbox icon.
  */
 function formatArtifactDisplay(artifact: MergedArtifact): string {
   const statusIcon = artifact.installed ? CHECKBOX_CHECKED : CHECKBOX_UNCHECKED;
   const description = artifact.description ? ` - ${artifact.description}` : '';
   return `${statusIcon} ${artifact.name}${description}`;
+}
+
+/**
+ * Format artifact name without status indicator.
+ * Used for checkbox prompts where the built-in checkbox shows status.
+ *
+ * @param artifact - The artifact to format.
+ * @returns Formatted display string without checkbox icon.
+ */
+function formatArtifactName(artifact: MergedArtifact): string {
+  const description = artifact.description ? ` - ${artifact.description}` : '';
+  return `${artifact.name}${description}`;
 }
 
 /**
@@ -103,10 +127,11 @@ export function toSelectChoices(groups: GroupedArtifacts): Array<{ name: string;
 
 /**
  * Convert artifacts to checkbox prompt choices, optionally filtered.
+ * Does NOT include manual checkbox icons - relies on @inquirer/checkbox's built-in display.
  *
  * @param artifacts - Array of artifacts.
  * @param filter - Optional filter: 'installed' or 'available'.
- * @returns Array of checkbox choices.
+ * @returns Array of checkbox choices without status prefix.
  */
 export function toCheckboxChoices(
   artifacts: MergedArtifact[],
@@ -121,13 +146,14 @@ export function toCheckboxChoices(
   }
 
   return filtered.map((artifact) => ({
-    name: formatArtifactDisplay(artifact),
+    name: formatArtifactName(artifact),
     value: artifact,
   }));
 }
 
 /**
  * Convert grouped artifacts to checkbox choices, grouped by type.
+ * Does NOT include manual checkbox icons - relies on @inquirer/checkbox's built-in display.
  *
  * @param groups - Grouped artifacts object.
  * @param filter - Optional filter: 'installed' or 'available'.
@@ -156,7 +182,7 @@ export function toGroupedCheckboxChoices(
 
     for (const artifact of group) {
       choices.push({
-        name: formatArtifactDisplay(artifact),
+        name: formatArtifactName(artifact),
         value: artifact,
       });
     }
@@ -250,6 +276,7 @@ export async function promptArtifactCheckbox(
       message,
       choices,
       pageSize: 15,
+      theme: CHECKBOX_THEME,
     });
   } catch (error) {
     if (isExitPromptError(error)) {
@@ -284,6 +311,7 @@ export async function promptGroupedCheckbox(
       message,
       choices,
       pageSize: 15,
+      theme: CHECKBOX_THEME,
     });
   } catch (error) {
     if (isExitPromptError(error)) {

--- a/src/ui/interactiveTable.ts
+++ b/src/ui/interactiveTable.ts
@@ -8,7 +8,7 @@ import { Separator } from '@inquirer/prompts';
 import type { GroupedArtifacts, MergedArtifact } from '../services/localFileScanner.js';
 
 /**
- * Checkbox characters for display.
+ * Checkbox characters for display in plain text output and select prompts.
  */
 const CHECKBOX_CHECKED = '\u2611'; // Checked box
 const CHECKBOX_UNCHECKED = '\u2610'; // Unchecked box
@@ -210,11 +210,12 @@ export class InteractiveTable {
   }
 
   /**
-   * Convert artifacts to checkbox prompt choices, optionally filtered by installation status.
+   * Convert artifacts to select prompt choices with status checkbox prefix.
+   * For use with @inquirer/select where we need to show installation status.
    *
    * @param artifacts - Array of artifacts.
    * @param filter - Optional filter: 'installed' or 'available'.
-   * @returns Array of checkbox choices.
+   * @returns Array of select choices with status indicator.
    */
   public static toCheckboxChoices(
     artifacts: MergedArtifact[],
@@ -233,6 +234,35 @@ export class InteractiveTable {
       const description = artifact.description ? ` - ${artifact.description}` : '';
       return {
         name: `${checkbox} ${artifact.name}${description}`,
+        value: artifact,
+      };
+    });
+  }
+
+  /**
+   * Convert artifacts to pure checkbox prompt choices (no manual status indicator).
+   * For use with @inquirer/checkbox which has built-in checked/unchecked display.
+   *
+   * @param artifacts - Array of artifacts.
+   * @param filter - Optional filter: 'installed' or 'available'.
+   * @returns Array of checkbox choices without status prefix.
+   */
+  public static toPureCheckboxChoices(
+    artifacts: MergedArtifact[],
+    filter?: 'installed' | 'available'
+  ): Array<{ name: string; value: MergedArtifact }> {
+    let filtered = artifacts;
+
+    if (filter === 'installed') {
+      filtered = artifacts.filter((a) => a.installed);
+    } else if (filter === 'available') {
+      filtered = artifacts.filter((a) => !a.installed);
+    }
+
+    return filtered.map((artifact) => {
+      const description = artifact.description ? ` - ${artifact.description}` : '';
+      return {
+        name: `${artifact.name}${description}`,
         value: artifact,
       };
     });


### PR DESCRIPTION
## Summary
- Add square checkboxes (☐/☑) consistently across all interactive prompts
- Display only artifact names without paths in list views  
- Add escape key handling to exit prompts gracefully
- Export `CHECKBOX_THEME` for reuse across commands
- Replace `pretty-quick` with `lint-staged` (fixes Node 24 compatibility)
- Disable prettier plugin auto-discovery (removes `prettier-plugin-apex` dependency)

## Test plan
- [ ] Run `sf aidev list` and verify square checkboxes appear
- [ ] Run `sf aidev add` and verify square checkboxes appear
- [ ] Run `sf aidev remove` and verify square checkboxes appear
- [ ] Press Escape in any interactive prompt to verify graceful exit
- [ ] Verify commits work without `prettier-plugin-apex` errors

🤖 Generated with [Claude Code](https://claude.ai/code)