### PR TITLE
fix(discovery): remove auto-discovered description from artifacts (#74)

### DIFF
--- a/src/sources/manifestBuilder.ts
+++ b/src/sources/manifestBuilder.ts
@@ -91,7 +91,6 @@ export class ManifestBuilder {
     const artifact: Artifact = {
       name,
       type,
-      description: `Auto-discovered ${type} from ${path}`,
       files: [{ source: path }],
     };
 

--- a/src/types/manifest.ts
+++ b/src/types/manifest.ts
@@ -28,8 +28,8 @@ export interface Artifact {
   name: string;
   /** Type of artifact */
   type: ArtifactType;
-  /** Human-readable description */
-  description: string;
+  /** Human-readable description (optional for auto-discovered artifacts) */
+  description?: string;
   /** Files that make up this artifact */
   files: ArtifactFile[];
   /** AI tools this artifact supports (empty means all tools) */

--- a/test/sources/manifestBuilder.test.ts
+++ b/test/sources/manifestBuilder.test.ts
@@ -269,12 +269,12 @@ describe('ManifestBuilder', () => {
       });
     });
 
-    describe('auto-generated description', () => {
-      it('generates description with artifact type and path', () => {
+    describe('auto-discovered artifacts', () => {
+      it('does not generate description for auto-discovered artifacts', () => {
         const paths = ['agents/my-agent.md'];
         const manifest = ManifestBuilder.build(paths);
 
-        expect(manifest.artifacts[0].description).to.equal('Auto-discovered agent from agents/my-agent.md');
+        expect(manifest.artifacts[0].description).to.be.undefined;
       });
     });
   });


### PR DESCRIPTION
## Summary

- Remove auto-generated description text (`Auto-discovered skill from skills/my-skill.md`) from `ManifestBuilder.createArtifact()`
- Make `description` field optional in `Artifact` interface
- Auto-discovered artifacts now only show their name in the list

## Changes

- `src/sources/manifestBuilder.ts` - Removed description generation
- `src/types/manifest.ts` - Made description field optional
- `test/sources/manifestBuilder.test.ts` - Updated test to verify no description

## Before
```
☐ my-skill - Auto-discovered skill from skills/my-skill.md
```

## After
```
☐ my-skill
```

Fixes #74

🤖 Generated with [Claude Code](https://claude.ai/code)