### PR TITLE
feat(ui): add Escape key support and interactive mode for add subcommands

### DIFF
--- a/messages/aidev.add.agent.md
+++ b/messages/aidev.add.agent.md
@@ -4,17 +4,21 @@ Install an agent from a configured source repository.
 
 # description
 
-Install an agent by name from a configured source repository. The agent is installed to the correct path for the detected AI tool (e.g., `.github/agents/` for Copilot, `.claude/agents/` for Claude).
+Install an agent by name from a configured source repository, or interactively select from available agents when no name is provided. The agent is installed to the correct path for the detected AI tool (e.g., `.github/agents/` for Copilot, `.claude/agents/` for Claude).
 
 # flags.name.summary
 
-Name of the agent to install.
+Name of the agent to install. If not provided, shows interactive selection.
 
 # flags.source.summary
 
 Source repository (owner/repo) to install from. Defaults to the configured default source.
 
 # examples
+
+- Interactively select agents to install:
+
+  <%= config.bin %> <%= command.id %>
 
 - Install an agent named "my-agent":
 
@@ -28,6 +32,58 @@ Source repository (owner/repo) to install from. Defaults to the configured defau
 
 Installation of agent "%s" failed: %s
 
+# error.NonInteractive
+
+This command requires an interactive terminal when no agent name is provided.
+
+# error.NonInteractiveActions
+
+Provide an agent name with --name flag, or run in an interactive terminal.
+
+# error.NoTool
+
+No AI tool is configured for this project.
+
+# error.NoToolActions
+
+Run `sf aidev init` to detect and configure an AI tool, or set one manually.
+
 # info.AgentInstalled
 
 Successfully installed agent "%s" to %s
+
+# info.Fetching
+
+Fetching available agents...
+
+# info.NoArtifacts
+
+No agents available in configured sources.
+
+# info.AllInstalled
+
+All available agents are already installed.
+
+# info.NoneSelected
+
+No agents selected for installation.
+
+# info.Installing
+
+Installing %s agent(s)...
+
+# info.Installed
+
+Successfully installed %s agent(s):
+
+# info.Skipped
+
+Skipped %s agent(s) (already installed):
+
+# warning.Failed
+
+Failed to install %s agent(s):
+
+# prompt.Select
+
+Select agents to install (use Space to select, Enter to confirm):

--- a/messages/aidev.add.prompt.md
+++ b/messages/aidev.add.prompt.md
@@ -4,17 +4,21 @@ Install a prompt from a configured source repository.
 
 # description
 
-Install a prompt by name from a configured source repository. The prompt is installed to the correct path for the detected AI tool (e.g., `.github/prompts/` for Copilot, `.claude/prompts/` for Claude).
+Install a prompt by name from a configured source repository, or interactively select from available prompts when no name is provided. The prompt is installed to the correct path for the detected AI tool (e.g., `.github/prompts/` for Copilot, `.claude/prompts/` for Claude).
 
 # flags.name.summary
 
-Name of the prompt to install.
+Name of the prompt to install. If not provided, shows interactive selection.
 
 # flags.source.summary
 
 Source repository (owner/repo) to install from. Defaults to the configured default source.
 
 # examples
+
+- Interactively select prompts to install:
+
+  <%= config.bin %> <%= command.id %>
 
 - Install a prompt named "my-prompt":
 
@@ -28,6 +32,58 @@ Source repository (owner/repo) to install from. Defaults to the configured defau
 
 Installation of prompt "%s" failed: %s
 
+# error.NonInteractive
+
+This command requires an interactive terminal when no prompt name is provided.
+
+# error.NonInteractiveActions
+
+Provide a prompt name with --name flag, or run in an interactive terminal.
+
+# error.NoTool
+
+No AI tool is configured for this project.
+
+# error.NoToolActions
+
+Run `sf aidev init` to detect and configure an AI tool, or set one manually.
+
 # info.PromptInstalled
 
 Successfully installed prompt "%s" to %s
+
+# info.Fetching
+
+Fetching available prompts...
+
+# info.NoArtifacts
+
+No prompts available in configured sources.
+
+# info.AllInstalled
+
+All available prompts are already installed.
+
+# info.NoneSelected
+
+No prompts selected for installation.
+
+# info.Installing
+
+Installing %s prompt(s)...
+
+# info.Installed
+
+Successfully installed %s prompt(s):
+
+# info.Skipped
+
+Skipped %s prompt(s) (already installed):
+
+# warning.Failed
+
+Failed to install %s prompt(s):
+
+# prompt.Select
+
+Select prompts to install (use Space to select, Enter to confirm):

--- a/messages/aidev.add.skill.md
+++ b/messages/aidev.add.skill.md
@@ -4,17 +4,21 @@ Install a skill from a configured source repository.
 
 # description
 
-Install a skill by name from a configured source repository. The skill is installed to the correct path for the detected AI tool (e.g., `.github/copilot-skills/` for Copilot, `.claude/skills/` for Claude).
+Install a skill by name from a configured source repository, or interactively select from available skills when no name is provided. The skill is installed to the correct path for the detected AI tool (e.g., `.github/copilot-skills/` for Copilot, `.claude/skills/` for Claude).
 
 # flags.name.summary
 
-Name of the skill to install.
+Name of the skill to install. If not provided, shows interactive selection.
 
 # flags.source.summary
 
 Source repository (owner/repo) to install from. Defaults to the configured default source.
 
 # examples
+
+- Interactively select skills to install:
+
+  <%= config.bin %> <%= command.id %>
 
 - Install a skill named "my-skill":
 
@@ -28,6 +32,58 @@ Source repository (owner/repo) to install from. Defaults to the configured defau
 
 Installation of skill "%s" failed: %s
 
+# error.NonInteractive
+
+This command requires an interactive terminal when no skill name is provided.
+
+# error.NonInteractiveActions
+
+Provide a skill name with --name flag, or run in an interactive terminal.
+
+# error.NoTool
+
+No AI tool is configured for this project.
+
+# error.NoToolActions
+
+Run `sf aidev init` to detect and configure an AI tool, or set one manually.
+
 # info.SkillInstalled
 
 Successfully installed skill "%s" to %s
+
+# info.Fetching
+
+Fetching available skills...
+
+# info.NoArtifacts
+
+No skills available in configured sources.
+
+# info.AllInstalled
+
+All available skills are already installed.
+
+# info.NoneSelected
+
+No skills selected for installation.
+
+# info.Installing
+
+Installing %s skill(s)...
+
+# info.Installed
+
+Successfully installed %s skill(s):
+
+# info.Skipped
+
+Skipped %s skill(s) (already installed):
+
+# warning.Failed
+
+Failed to install %s skill(s):
+
+# prompt.Select
+
+Select skills to install (use Space to select, Enter to confirm):

--- a/src/commands/aidev/add.ts
+++ b/src/commands/aidev/add.ts
@@ -6,11 +6,11 @@
 
 import { SfCommand, Flags } from '@salesforce/sf-plugins-core';
 import { Messages, SfError } from '@salesforce/core';
-import { checkbox, Separator } from '@inquirer/prompts';
+import { Separator } from '@inquirer/prompts';
 import { ArtifactService, type InstallResult, type AvailableArtifact } from '../../services/artifactService.js';
 import { AiDevConfig } from '../../config/aiDevConfig.js';
 import type { ArtifactType } from '../../types/manifest.js';
-import { CHECKBOX_THEME } from '../../ui/interactivePrompts.js';
+import { CHECKBOX_THEME, promptCheckboxGeneric } from '../../ui/interactivePrompts.js';
 
 Messages.importMessagesDirectoryFromMetaUrl(import.meta.url);
 const messages = Messages.loadMessages('sf-aidev', 'aidev.add');
@@ -187,25 +187,17 @@ export default class Add extends SfCommand<AddResult> {
    */
   protected async promptCheckbox(
     message: string,
-    choices: Array<CheckboxChoice | Separator>
+    choices: Array<CheckboxChoice | Separator>,
   ): Promise<AvailableArtifact[]> {
     // Use this.spinner to satisfy class-methods-use-this rule
     // The spinner is already stopped before this method is called
     void this.spinner;
-    try {
-      return await checkbox<AvailableArtifact>({
-        message,
-        choices,
-        pageSize: 15,
-        theme: CHECKBOX_THEME,
-      });
-    } catch (error) {
-      // Handle user cancellation (Escape/Ctrl+C)
-      if (error instanceof Error && error.name === 'ExitPromptError') {
-        return [];
-      }
-      throw error;
-    }
+    return promptCheckboxGeneric<AvailableArtifact>({
+      message,
+      choices,
+      pageSize: 15,
+      theme: CHECKBOX_THEME,
+    });
   }
 
   /**

--- a/src/commands/aidev/add/agent.ts
+++ b/src/commands/aidev/add/agent.ts
@@ -6,13 +6,35 @@
 
 import { SfCommand, Flags } from '@salesforce/sf-plugins-core';
 import { Messages, SfError } from '@salesforce/core';
-import { ArtifactService, type InstallResult } from '../../../services/artifactService.js';
+import { Separator } from '@inquirer/prompts';
+import { ArtifactService, type InstallResult, type AvailableArtifact } from '../../../services/artifactService.js';
 import { AiDevConfig } from '../../../config/aiDevConfig.js';
+import { isInteractive, promptCheckboxGeneric, CHECKBOX_THEME } from '../../../ui/interactivePrompts.js';
 
 Messages.importMessagesDirectoryFromMetaUrl(import.meta.url);
 const messages = Messages.loadMessages('sf-aidev', 'aidev.add.agent');
 
-export type AddAgentResult = InstallResult;
+/**
+ * Result type for single agent installation
+ */
+export type AddAgentResult = InstallResult | AddAgentMultiResult;
+
+/**
+ * Result type for multiple agent installation (interactive mode)
+ */
+export type AddAgentMultiResult = {
+  installed: InstallResult[];
+  skipped: Array<{ name: string }>;
+  total: number;
+};
+
+/**
+ * Checkbox choice type for interactive selection
+ */
+type CheckboxChoice = {
+  name: string;
+  value: AvailableArtifact;
+};
 
 export default class AddAgent extends SfCommand<AddAgentResult> {
   public static readonly summary = messages.getMessage('summary');
@@ -24,7 +46,7 @@ export default class AddAgent extends SfCommand<AddAgentResult> {
     name: Flags.string({
       char: 'n',
       summary: messages.getMessage('flags.name.summary'),
-      required: true,
+      required: false,
     }),
     source: Flags.string({
       char: 's',
@@ -39,16 +61,169 @@ export default class AddAgent extends SfCommand<AddAgentResult> {
     const localConfig = await AiDevConfig.create({ isGlobal: false });
     const service = new ArtifactService(globalConfig, localConfig, process.cwd());
 
-    const result: InstallResult = await service.install(flags.name, { type: 'agent', source: flags.source });
+    // If name is provided, install directly (non-interactive mode)
+    if (flags.name) {
+      return this.installSingle(service, flags.name, flags.source);
+    }
+
+    // Interactive mode - name not provided
+    if (!isInteractive()) {
+      throw new SfError(messages.getMessage('error.NonInteractive'), 'NonInteractiveError', [
+        messages.getMessage('error.NonInteractiveActions'),
+      ]);
+    }
+
+    return this.runInteractive(service, flags.source);
+  }
+
+  /**
+   * Prompt user with a multi-select checkbox.
+   * Extracted for test stubbing.
+   */
+  // eslint-disable-next-line class-methods-use-this
+  protected async promptCheckbox(
+    message: string,
+    choices: Array<CheckboxChoice | Separator>,
+  ): Promise<AvailableArtifact[]> {
+    return promptCheckboxGeneric<AvailableArtifact>({
+      message,
+      choices,
+      pageSize: 15,
+      theme: CHECKBOX_THEME,
+    });
+  }
+
+  /**
+   * Install a single agent by name (non-interactive mode).
+   */
+  private async installSingle(service: ArtifactService, name: string, source?: string): Promise<InstallResult> {
+    const result: InstallResult = await service.install(name, { type: 'agent', source });
 
     if (!result.success) {
       throw new SfError(
-        messages.getMessage('error.InstallFailed', [flags.name, result.error ?? 'Unknown error']),
-        'InstallError'
+        messages.getMessage('error.InstallFailed', [name, result.error ?? 'Unknown error']),
+        'InstallError',
       );
     }
 
     this.log(messages.getMessage('info.AgentInstalled', [result.artifact, result.installedPath]));
     return result;
+  }
+
+  /**
+   * Run interactive mode - show checkbox list of available agents.
+   */
+  private async runInteractive(service: ArtifactService, source?: string): Promise<AddAgentMultiResult> {
+    // Ensure a tool is configured
+    const tool = service.getActiveTool();
+    if (!tool) {
+      throw new SfError(messages.getMessage('error.NoTool'), 'NoToolError', [
+        messages.getMessage('error.NoToolActions'),
+      ]);
+    }
+
+    // Fetch available artifacts filtered to agents only
+    this.spinner.start(messages.getMessage('info.Fetching'));
+    const available = await service.listAvailable({ source, type: 'agent' });
+    this.spinner.stop();
+
+    // Filter out already installed
+    const notInstalled = available.filter((a) => !a.installed);
+
+    if (available.length === 0) {
+      this.log(messages.getMessage('info.NoArtifacts'));
+      return { installed: [], skipped: [], total: 0 };
+    }
+
+    if (notInstalled.length === 0) {
+      this.log(messages.getMessage('info.AllInstalled'));
+      return { installed: [], skipped: [], total: 0 };
+    }
+
+    // Build choices
+    const choices = this.buildChoices(notInstalled);
+
+    // Prompt user to select agents
+    const selected = await this.promptCheckbox(messages.getMessage('prompt.Select'), choices);
+
+    if (selected.length === 0) {
+      this.log(messages.getMessage('info.NoneSelected'));
+      return { installed: [], skipped: [], total: 0 };
+    }
+
+    // Install selected agents
+    const installed: InstallResult[] = [];
+    const skipped: Array<{ name: string }> = [];
+
+    this.spinner.start(messages.getMessage('info.Installing', [selected.length.toString()]));
+
+    for (const artifact of selected) {
+      // Double-check if agent was installed in the meantime
+      if (service.isInstalled(artifact.name, 'agent')) {
+        skipped.push({ name: artifact.name });
+        continue;
+      }
+
+      // eslint-disable-next-line no-await-in-loop
+      const result = await service.install(artifact.name, {
+        type: 'agent',
+        source: artifact.source,
+      });
+      installed.push(result);
+    }
+
+    this.spinner.stop();
+
+    // Report results
+    this.reportResults(installed, skipped);
+
+    return {
+      installed,
+      skipped,
+      total: selected.length,
+    };
+  }
+
+  /**
+   * Build checkbox choices from available artifacts.
+   */
+  // eslint-disable-next-line class-methods-use-this
+  private buildChoices(artifacts: AvailableArtifact[]): Array<CheckboxChoice | Separator> {
+    return artifacts.map((artifact) => {
+      const displayName = artifact.description ? `${artifact.name} - ${artifact.description}` : artifact.name;
+      return {
+        name: displayName,
+        value: artifact,
+      };
+    });
+  }
+
+  /**
+   * Report installation results to the user.
+   */
+  private reportResults(installed: InstallResult[], skipped: Array<{ name: string }>): void {
+    const successful = installed.filter((r) => r.success);
+    const failed = installed.filter((r) => !r.success);
+
+    if (successful.length > 0) {
+      this.log(messages.getMessage('info.Installed', [successful.length.toString()]));
+      for (const result of successful) {
+        this.log(`  - ${result.artifact} -> ${result.installedPath}`);
+      }
+    }
+
+    if (skipped.length > 0) {
+      this.log(messages.getMessage('info.Skipped', [skipped.length.toString()]));
+      for (const item of skipped) {
+        this.log(`  - ${item.name}`);
+      }
+    }
+
+    if (failed.length > 0) {
+      this.warn(messages.getMessage('warning.Failed', [failed.length.toString()]));
+      for (const result of failed) {
+        this.log(`  - ${result.artifact}: ${result.error ?? 'Unknown error'}`);
+      }
+    }
   }
 }

--- a/src/commands/aidev/add/prompt.ts
+++ b/src/commands/aidev/add/prompt.ts
@@ -6,13 +6,35 @@
 
 import { SfCommand, Flags } from '@salesforce/sf-plugins-core';
 import { Messages, SfError } from '@salesforce/core';
-import { ArtifactService, type InstallResult } from '../../../services/artifactService.js';
+import { Separator } from '@inquirer/prompts';
+import { ArtifactService, type InstallResult, type AvailableArtifact } from '../../../services/artifactService.js';
 import { AiDevConfig } from '../../../config/aiDevConfig.js';
+import { isInteractive, promptCheckboxGeneric, CHECKBOX_THEME } from '../../../ui/interactivePrompts.js';
 
 Messages.importMessagesDirectoryFromMetaUrl(import.meta.url);
 const messages = Messages.loadMessages('sf-aidev', 'aidev.add.prompt');
 
-export type AddPromptResult = InstallResult;
+/**
+ * Result type for single prompt installation
+ */
+export type AddPromptResult = InstallResult | AddPromptMultiResult;
+
+/**
+ * Result type for multiple prompt installation (interactive mode)
+ */
+export type AddPromptMultiResult = {
+  installed: InstallResult[];
+  skipped: Array<{ name: string }>;
+  total: number;
+};
+
+/**
+ * Checkbox choice type for interactive selection
+ */
+type CheckboxChoice = {
+  name: string;
+  value: AvailableArtifact;
+};
 
 export default class AddPrompt extends SfCommand<AddPromptResult> {
   public static readonly summary = messages.getMessage('summary');
@@ -24,7 +46,7 @@ export default class AddPrompt extends SfCommand<AddPromptResult> {
     name: Flags.string({
       char: 'n',
       summary: messages.getMessage('flags.name.summary'),
-      required: true,
+      required: false,
     }),
     source: Flags.string({
       char: 's',
@@ -39,16 +61,169 @@ export default class AddPrompt extends SfCommand<AddPromptResult> {
     const localConfig = await AiDevConfig.create({ isGlobal: false });
     const service = new ArtifactService(globalConfig, localConfig, process.cwd());
 
-    const result: InstallResult = await service.install(flags.name, { type: 'prompt', source: flags.source });
+    // If name is provided, install directly (non-interactive mode)
+    if (flags.name) {
+      return this.installSingle(service, flags.name, flags.source);
+    }
+
+    // Interactive mode - name not provided
+    if (!isInteractive()) {
+      throw new SfError(messages.getMessage('error.NonInteractive'), 'NonInteractiveError', [
+        messages.getMessage('error.NonInteractiveActions'),
+      ]);
+    }
+
+    return this.runInteractive(service, flags.source);
+  }
+
+  /**
+   * Prompt user with a multi-select checkbox.
+   * Extracted for test stubbing.
+   */
+  // eslint-disable-next-line class-methods-use-this
+  protected async promptCheckbox(
+    message: string,
+    choices: Array<CheckboxChoice | Separator>,
+  ): Promise<AvailableArtifact[]> {
+    return promptCheckboxGeneric<AvailableArtifact>({
+      message,
+      choices,
+      pageSize: 15,
+      theme: CHECKBOX_THEME,
+    });
+  }
+
+  /**
+   * Install a single prompt by name (non-interactive mode).
+   */
+  private async installSingle(service: ArtifactService, name: string, source?: string): Promise<InstallResult> {
+    const result: InstallResult = await service.install(name, { type: 'prompt', source });
 
     if (!result.success) {
       throw new SfError(
-        messages.getMessage('error.InstallFailed', [flags.name, result.error ?? 'Unknown error']),
-        'InstallError'
+        messages.getMessage('error.InstallFailed', [name, result.error ?? 'Unknown error']),
+        'InstallError',
       );
     }
 
     this.log(messages.getMessage('info.PromptInstalled', [result.artifact, result.installedPath]));
     return result;
+  }
+
+  /**
+   * Run interactive mode - show checkbox list of available prompts.
+   */
+  private async runInteractive(service: ArtifactService, source?: string): Promise<AddPromptMultiResult> {
+    // Ensure a tool is configured
+    const tool = service.getActiveTool();
+    if (!tool) {
+      throw new SfError(messages.getMessage('error.NoTool'), 'NoToolError', [
+        messages.getMessage('error.NoToolActions'),
+      ]);
+    }
+
+    // Fetch available artifacts filtered to prompts only
+    this.spinner.start(messages.getMessage('info.Fetching'));
+    const available = await service.listAvailable({ source, type: 'prompt' });
+    this.spinner.stop();
+
+    // Filter out already installed
+    const notInstalled = available.filter((a) => !a.installed);
+
+    if (available.length === 0) {
+      this.log(messages.getMessage('info.NoArtifacts'));
+      return { installed: [], skipped: [], total: 0 };
+    }
+
+    if (notInstalled.length === 0) {
+      this.log(messages.getMessage('info.AllInstalled'));
+      return { installed: [], skipped: [], total: 0 };
+    }
+
+    // Build choices
+    const choices = this.buildChoices(notInstalled);
+
+    // Prompt user to select prompts
+    const selected = await this.promptCheckbox(messages.getMessage('prompt.Select'), choices);
+
+    if (selected.length === 0) {
+      this.log(messages.getMessage('info.NoneSelected'));
+      return { installed: [], skipped: [], total: 0 };
+    }
+
+    // Install selected prompts
+    const installed: InstallResult[] = [];
+    const skipped: Array<{ name: string }> = [];
+
+    this.spinner.start(messages.getMessage('info.Installing', [selected.length.toString()]));
+
+    for (const artifact of selected) {
+      // Double-check if prompt was installed in the meantime
+      if (service.isInstalled(artifact.name, 'prompt')) {
+        skipped.push({ name: artifact.name });
+        continue;
+      }
+
+      // eslint-disable-next-line no-await-in-loop
+      const result = await service.install(artifact.name, {
+        type: 'prompt',
+        source: artifact.source,
+      });
+      installed.push(result);
+    }
+
+    this.spinner.stop();
+
+    // Report results
+    this.reportResults(installed, skipped);
+
+    return {
+      installed,
+      skipped,
+      total: selected.length,
+    };
+  }
+
+  /**
+   * Build checkbox choices from available artifacts.
+   */
+  // eslint-disable-next-line class-methods-use-this
+  private buildChoices(artifacts: AvailableArtifact[]): Array<CheckboxChoice | Separator> {
+    return artifacts.map((artifact) => {
+      const displayName = artifact.description ? `${artifact.name} - ${artifact.description}` : artifact.name;
+      return {
+        name: displayName,
+        value: artifact,
+      };
+    });
+  }
+
+  /**
+   * Report installation results to the user.
+   */
+  private reportResults(installed: InstallResult[], skipped: Array<{ name: string }>): void {
+    const successful = installed.filter((r) => r.success);
+    const failed = installed.filter((r) => !r.success);
+
+    if (successful.length > 0) {
+      this.log(messages.getMessage('info.Installed', [successful.length.toString()]));
+      for (const result of successful) {
+        this.log(`  - ${result.artifact} -> ${result.installedPath}`);
+      }
+    }
+
+    if (skipped.length > 0) {
+      this.log(messages.getMessage('info.Skipped', [skipped.length.toString()]));
+      for (const item of skipped) {
+        this.log(`  - ${item.name}`);
+      }
+    }
+
+    if (failed.length > 0) {
+      this.warn(messages.getMessage('warning.Failed', [failed.length.toString()]));
+      for (const result of failed) {
+        this.log(`  - ${result.artifact}: ${result.error ?? 'Unknown error'}`);
+      }
+    }
   }
 }

--- a/src/commands/aidev/add/skill.ts
+++ b/src/commands/aidev/add/skill.ts
@@ -6,13 +6,35 @@
 
 import { SfCommand, Flags } from '@salesforce/sf-plugins-core';
 import { Messages, SfError } from '@salesforce/core';
-import { ArtifactService, type InstallResult } from '../../../services/artifactService.js';
+import { Separator } from '@inquirer/prompts';
+import { ArtifactService, type InstallResult, type AvailableArtifact } from '../../../services/artifactService.js';
 import { AiDevConfig } from '../../../config/aiDevConfig.js';
+import { isInteractive, promptCheckboxGeneric, CHECKBOX_THEME } from '../../../ui/interactivePrompts.js';
 
 Messages.importMessagesDirectoryFromMetaUrl(import.meta.url);
 const messages = Messages.loadMessages('sf-aidev', 'aidev.add.skill');
 
-export type AddSkillResult = InstallResult;
+/**
+ * Result type for single skill installation
+ */
+export type AddSkillResult = InstallResult | AddSkillMultiResult;
+
+/**
+ * Result type for multiple skill installation (interactive mode)
+ */
+export type AddSkillMultiResult = {
+  installed: InstallResult[];
+  skipped: Array<{ name: string }>;
+  total: number;
+};
+
+/**
+ * Checkbox choice type for interactive selection
+ */
+type CheckboxChoice = {
+  name: string;
+  value: AvailableArtifact;
+};
 
 export default class AddSkill extends SfCommand<AddSkillResult> {
   public static readonly summary = messages.getMessage('summary');
@@ -24,7 +46,7 @@ export default class AddSkill extends SfCommand<AddSkillResult> {
     name: Flags.string({
       char: 'n',
       summary: messages.getMessage('flags.name.summary'),
-      required: true,
+      required: false,
     }),
     source: Flags.string({
       char: 's',
@@ -39,16 +61,169 @@ export default class AddSkill extends SfCommand<AddSkillResult> {
     const localConfig = await AiDevConfig.create({ isGlobal: false });
     const service = new ArtifactService(globalConfig, localConfig, process.cwd());
 
-    const result = await service.install(flags.name, { type: 'skill', source: flags.source });
+    // If name is provided, install directly (non-interactive mode)
+    if (flags.name) {
+      return this.installSingle(service, flags.name, flags.source);
+    }
+
+    // Interactive mode - name not provided
+    if (!isInteractive()) {
+      throw new SfError(messages.getMessage('error.NonInteractive'), 'NonInteractiveError', [
+        messages.getMessage('error.NonInteractiveActions'),
+      ]);
+    }
+
+    return this.runInteractive(service, flags.source);
+  }
+
+  /**
+   * Prompt user with a multi-select checkbox.
+   * Extracted for test stubbing.
+   */
+  // eslint-disable-next-line class-methods-use-this
+  protected async promptCheckbox(
+    message: string,
+    choices: Array<CheckboxChoice | Separator>,
+  ): Promise<AvailableArtifact[]> {
+    return promptCheckboxGeneric<AvailableArtifact>({
+      message,
+      choices,
+      pageSize: 15,
+      theme: CHECKBOX_THEME,
+    });
+  }
+
+  /**
+   * Install a single skill by name (non-interactive mode).
+   */
+  private async installSingle(service: ArtifactService, name: string, source?: string): Promise<InstallResult> {
+    const result = await service.install(name, { type: 'skill', source });
 
     if (!result.success) {
       throw new SfError(
-        messages.getMessage('error.InstallFailed', [flags.name, result.error ?? 'Unknown error']),
-        'InstallError'
+        messages.getMessage('error.InstallFailed', [name, result.error ?? 'Unknown error']),
+        'InstallError',
       );
     }
 
     this.log(messages.getMessage('info.SkillInstalled', [result.artifact, result.installedPath]));
     return result;
+  }
+
+  /**
+   * Run interactive mode - show checkbox list of available skills.
+   */
+  private async runInteractive(service: ArtifactService, source?: string): Promise<AddSkillMultiResult> {
+    // Ensure a tool is configured
+    const tool = service.getActiveTool();
+    if (!tool) {
+      throw new SfError(messages.getMessage('error.NoTool'), 'NoToolError', [
+        messages.getMessage('error.NoToolActions'),
+      ]);
+    }
+
+    // Fetch available artifacts filtered to skills only
+    this.spinner.start(messages.getMessage('info.Fetching'));
+    const available = await service.listAvailable({ source, type: 'skill' });
+    this.spinner.stop();
+
+    // Filter out already installed
+    const notInstalled = available.filter((a) => !a.installed);
+
+    if (available.length === 0) {
+      this.log(messages.getMessage('info.NoArtifacts'));
+      return { installed: [], skipped: [], total: 0 };
+    }
+
+    if (notInstalled.length === 0) {
+      this.log(messages.getMessage('info.AllInstalled'));
+      return { installed: [], skipped: [], total: 0 };
+    }
+
+    // Build choices
+    const choices = this.buildChoices(notInstalled);
+
+    // Prompt user to select skills
+    const selected = await this.promptCheckbox(messages.getMessage('prompt.Select'), choices);
+
+    if (selected.length === 0) {
+      this.log(messages.getMessage('info.NoneSelected'));
+      return { installed: [], skipped: [], total: 0 };
+    }
+
+    // Install selected skills
+    const installed: InstallResult[] = [];
+    const skipped: Array<{ name: string }> = [];
+
+    this.spinner.start(messages.getMessage('info.Installing', [selected.length.toString()]));
+
+    for (const artifact of selected) {
+      // Double-check if skill was installed in the meantime
+      if (service.isInstalled(artifact.name, 'skill')) {
+        skipped.push({ name: artifact.name });
+        continue;
+      }
+
+      // eslint-disable-next-line no-await-in-loop
+      const result = await service.install(artifact.name, {
+        type: 'skill',
+        source: artifact.source,
+      });
+      installed.push(result);
+    }
+
+    this.spinner.stop();
+
+    // Report results
+    this.reportResults(installed, skipped);
+
+    return {
+      installed,
+      skipped,
+      total: selected.length,
+    };
+  }
+
+  /**
+   * Build checkbox choices from available artifacts.
+   */
+  // eslint-disable-next-line class-methods-use-this
+  private buildChoices(artifacts: AvailableArtifact[]): Array<CheckboxChoice | Separator> {
+    return artifacts.map((artifact) => {
+      const displayName = artifact.description ? `${artifact.name} - ${artifact.description}` : artifact.name;
+      return {
+        name: displayName,
+        value: artifact,
+      };
+    });
+  }
+
+  /**
+   * Report installation results to the user.
+   */
+  private reportResults(installed: InstallResult[], skipped: Array<{ name: string }>): void {
+    const successful = installed.filter((r) => r.success);
+    const failed = installed.filter((r) => !r.success);
+
+    if (successful.length > 0) {
+      this.log(messages.getMessage('info.Installed', [successful.length.toString()]));
+      for (const result of successful) {
+        this.log(`  - ${result.artifact} -> ${result.installedPath}`);
+      }
+    }
+
+    if (skipped.length > 0) {
+      this.log(messages.getMessage('info.Skipped', [skipped.length.toString()]));
+      for (const item of skipped) {
+        this.log(`  - ${item.name}`);
+      }
+    }
+
+    if (failed.length > 0) {
+      this.warn(messages.getMessage('warning.Failed', [failed.length.toString()]));
+      for (const result of failed) {
+        this.log(`  - ${result.artifact}: ${result.error ?? 'Unknown error'}`);
+      }
+    }
   }
 }

--- a/src/commands/aidev/remove/index.ts
+++ b/src/commands/aidev/remove/index.ts
@@ -6,11 +6,10 @@
 
 import { SfCommand, Flags } from '@salesforce/sf-plugins-core';
 import { Messages, SfError } from '@salesforce/core';
-import { confirm } from '@inquirer/prompts';
 import { ArtifactService } from '../../../services/artifactService.js';
 import { LocalFileScanner, type GroupedArtifacts, type MergedArtifact } from '../../../services/localFileScanner.js';
 import { AiDevConfig } from '../../../config/aiDevConfig.js';
-import { isInteractive, promptGroupedCheckbox } from '../../../ui/interactivePrompts.js';
+import { isInteractive, promptGroupedCheckbox, promptConfirm } from '../../../ui/interactivePrompts.js';
 import type { ArtifactType } from '../../../types/manifest.js';
 
 Messages.importMessagesDirectoryFromMetaUrl(import.meta.url);
@@ -156,17 +155,7 @@ export default class Remove extends SfCommand<RemoveResult> {
    */
   // eslint-disable-next-line class-methods-use-this
   protected async confirmRemoval(count: number): Promise<boolean> {
-    try {
-      return await confirm({
-        message: messages.getMessage('prompt.Confirm', [count.toString()]),
-        default: false,
-      });
-    } catch (error) {
-      if (error instanceof Error && error.name === 'ExitPromptError') {
-        return false;
-      }
-      throw error;
-    }
+    return promptConfirm(messages.getMessage('prompt.Confirm', [count.toString()]), false);
   }
 
   /**

--- a/src/ui/interactivePrompts.ts
+++ b/src/ui/interactivePrompts.ts
@@ -4,7 +4,8 @@
  * Licensed under the BSD 3-Clause license.
  */
 
-import { select, checkbox, Separator } from '@inquirer/prompts';
+import * as readline from 'node:readline';
+import { select, checkbox, confirm, Separator } from '@inquirer/prompts';
 import type { GroupedArtifacts, MergedArtifact } from '../services/localFileScanner.js';
 import type { ArtifactType } from '../types/manifest.js';
 
@@ -20,6 +21,42 @@ const CHECKBOX_UNCHECKED = '\u2610'; // Unchecked box (empty square)
 const SELECT_HELP = '(↑↓ navigate, Enter select, Esc exit)';
 const CHECKBOX_HELP = '(↑↓ navigate, Space toggle, Enter confirm, Esc cancel)';
 const ACTION_HELP = '(↑↓ navigate, Enter select, Esc back)';
+
+/**
+ * Cancellable promise type returned by @inquirer/prompts.
+ */
+type CancellablePromise<T> = Promise<T> & { cancel: () => void };
+
+/**
+ * Wrap a cancellable prompt with Escape key handling.
+ *
+ * @inquirer/prompts doesn't handle Escape key natively - only Ctrl+C.
+ * This wrapper listens for Escape and calls the prompt's cancel() method.
+ */
+async function withEscapeHandling<T>(prompt: CancellablePromise<T>): Promise<T> {
+  // Set up raw mode to capture Escape key
+  if (process.stdin.isTTY) {
+    const onKeypress = (_chunk: string, key: readline.Key): void => {
+      if (key && key.name === 'escape') {
+        prompt.cancel();
+      }
+    };
+
+    // Enable keypress events
+    if (!process.stdin.listenerCount('keypress')) {
+      readline.emitKeypressEvents(process.stdin);
+    }
+    process.stdin.on('keypress', onKeypress);
+
+    try {
+      return await prompt;
+    } finally {
+      process.stdin.removeListener('keypress', onKeypress);
+    }
+  }
+
+  return prompt;
+}
 
 /**
  * Custom theme for @inquirer/checkbox prompt with square checkboxes.
@@ -55,15 +92,16 @@ export function isInteractive(): boolean {
 }
 
 /**
- * Check if an error is an ExitPromptError (user pressed Escape or Ctrl+C).
+ * Check if an error indicates user cancellation.
+ * - ExitPromptError: thrown when user presses Ctrl+C (SIGINT)
+ * - CancelPromptError: thrown when prompt.cancel() is called (e.g., on Escape)
  *
  * @param error - The error to check.
  * @returns True if the error indicates user cancellation.
  */
-function isExitPromptError(error: unknown): boolean {
+function isCancelledError(error: unknown): boolean {
   if (error instanceof Error) {
-    // @inquirer/prompts throws ExitPromptError when user presses Escape or Ctrl+C
-    return error.name === 'ExitPromptError';
+    return error.name === 'ExitPromptError' || error.name === 'CancelPromptError';
   }
   return false;
 }
@@ -214,13 +252,16 @@ export async function promptArtifactList(groups: GroupedArtifacts, message: stri
   }
 
   try {
-    return await select<MergedArtifact>({
-      message: `${message} ${SELECT_HELP}`,
-      choices,
-      pageSize: 15,
-    });
+    // Cast needed because @inquirer/prompts types don't expose CancelablePromise
+    return await withEscapeHandling(
+      select<MergedArtifact>({
+        message: `${message} ${SELECT_HELP}`,
+        choices,
+        pageSize: 15,
+      }) as CancellablePromise<MergedArtifact>,
+    );
   } catch (error) {
-    if (isExitPromptError(error)) {
+    if (isCancelledError(error)) {
       return null;
     }
     throw error;
@@ -246,12 +287,15 @@ export async function promptArtifactAction(artifact: MergedArtifact): Promise<Ar
   choices.push({ name: 'Back to list', value: 'back' });
 
   try {
-    return await select<ArtifactAction>({
-      message: `Action for "${artifact.name}" (${TYPE_LABELS[artifact.type]}): ${ACTION_HELP}`,
-      choices,
-    });
+    // Cast needed because @inquirer/prompts types don't expose CancelablePromise
+    return await withEscapeHandling(
+      select<ArtifactAction>({
+        message: `Action for "${artifact.name}" (${TYPE_LABELS[artifact.type]}): ${ACTION_HELP}`,
+        choices,
+      }) as CancellablePromise<ArtifactAction>,
+    );
   } catch (error) {
-    if (isExitPromptError(error)) {
+    if (isCancelledError(error)) {
       return null;
     }
     throw error;
@@ -279,14 +323,17 @@ export async function promptArtifactCheckbox(
   }
 
   try {
-    return await checkbox<MergedArtifact>({
-      message: `${message} ${CHECKBOX_HELP}`,
-      choices,
-      pageSize: 15,
-      theme: CHECKBOX_THEME,
-    });
+    // Cast needed because @inquirer/prompts types don't expose CancelablePromise
+    return await withEscapeHandling(
+      checkbox<MergedArtifact>({
+        message: `${message} ${CHECKBOX_HELP}`,
+        choices,
+        pageSize: 15,
+        theme: CHECKBOX_THEME,
+      }) as CancellablePromise<MergedArtifact[]>,
+    );
   } catch (error) {
-    if (isExitPromptError(error)) {
+    if (isCancelledError(error)) {
       return [];
     }
     throw error;
@@ -314,14 +361,77 @@ export async function promptGroupedCheckbox(
   }
 
   try {
-    return await checkbox<MergedArtifact>({
-      message: `${message} ${CHECKBOX_HELP}`,
-      choices,
-      pageSize: 15,
-      theme: CHECKBOX_THEME,
-    });
+    // Cast needed because @inquirer/prompts types don't expose CancelablePromise
+    return await withEscapeHandling(
+      checkbox<MergedArtifact>({
+        message: `${message} ${CHECKBOX_HELP}`,
+        choices,
+        pageSize: 15,
+        theme: CHECKBOX_THEME,
+      }) as CancellablePromise<MergedArtifact[]>,
+    );
   } catch (error) {
-    if (isExitPromptError(error)) {
+    if (isCancelledError(error)) {
+      return [];
+    }
+    throw error;
+  }
+}
+
+/**
+ * Prompt user for confirmation with Escape key support.
+ * Returns false if user cancels (Escape/Ctrl+C).
+ *
+ * @param message - The confirmation message to display.
+ * @param defaultValue - Default value (default: false).
+ * @returns True if confirmed, false otherwise.
+ */
+export async function promptConfirm(message: string, defaultValue = false): Promise<boolean> {
+  try {
+    // Cast needed because @inquirer/prompts types don't expose CancelablePromise
+    return await withEscapeHandling(
+      confirm({
+        message,
+        default: defaultValue,
+      }) as CancellablePromise<boolean>,
+    );
+  } catch (error) {
+    if (isCancelledError(error)) {
+      return false;
+    }
+    throw error;
+  }
+}
+
+/**
+ * Generic checkbox prompt with Escape key support.
+ * Returns empty array if user cancels (Escape/Ctrl+C).
+ *
+ * @param config - Checkbox configuration (message, choices, pageSize, theme).
+ * @returns Array of selected values.
+ */
+export async function promptCheckboxGeneric<T>(config: {
+  message: string;
+  choices: Array<{ name: string; value: T } | Separator>;
+  pageSize?: number;
+  theme?: typeof CHECKBOX_THEME;
+}): Promise<T[]> {
+  if (config.choices.length === 0) {
+    return [];
+  }
+
+  try {
+    // Cast needed because @inquirer/prompts types don't expose CancelablePromise
+    return await withEscapeHandling(
+      checkbox<T>({
+        message: config.message,
+        choices: config.choices,
+        pageSize: config.pageSize ?? 15,
+        theme: config.theme ?? CHECKBOX_THEME,
+      }) as CancellablePromise<T[]>,
+    );
+  } catch (error) {
+    if (isCancelledError(error)) {
       return [];
     }
     throw error;

--- a/test/commands/aidev/add/agent.test.ts
+++ b/test/commands/aidev/add/agent.test.ts
@@ -74,7 +74,7 @@ describe('aidev add agent', () => {
 
       const result = await AddAgent.run(['--name', 'my-agent', '--source', 'owner/repo'], oclifConfig);
 
-      expect(result.success).to.be.true;
+      expect('success' in result && result.success).to.be.true;
       expect(installStub.firstCall.args[1]).to.deep.equal({ type: 'agent', source: 'owner/repo' });
     });
 
@@ -83,7 +83,7 @@ describe('aidev add agent', () => {
 
       const result = await AddAgent.run(['-n', 'my-agent'], oclifConfig);
 
-      expect(result.success).to.be.true;
+      expect('success' in result && result.success).to.be.true;
       expect(installStub.firstCall.args[0]).to.equal('my-agent');
     });
 

--- a/test/commands/aidev/add/prompt.test.ts
+++ b/test/commands/aidev/add/prompt.test.ts
@@ -74,7 +74,7 @@ describe('aidev add prompt', () => {
 
       const result = await AddPrompt.run(['--name', 'my-prompt', '--source', 'owner/repo'], oclifConfig);
 
-      expect(result.success).to.be.true;
+      expect('success' in result && result.success).to.be.true;
       expect(installStub.firstCall.args[1]).to.deep.equal({ type: 'prompt', source: 'owner/repo' });
     });
 
@@ -83,7 +83,7 @@ describe('aidev add prompt', () => {
 
       const result = await AddPrompt.run(['-n', 'my-prompt'], oclifConfig);
 
-      expect(result.success).to.be.true;
+      expect('success' in result && result.success).to.be.true;
       expect(installStub.firstCall.args[0]).to.equal('my-prompt');
     });
 

--- a/test/commands/aidev/add/skill.test.ts
+++ b/test/commands/aidev/add/skill.test.ts
@@ -74,7 +74,7 @@ describe('aidev add skill', () => {
 
       const result = await AddSkill.run(['--name', 'my-skill', '--source', 'owner/repo'], oclifConfig);
 
-      expect(result.success).to.be.true;
+      expect('success' in result && result.success).to.be.true;
       expect(installStub.firstCall.args[1]).to.deep.equal({ type: 'skill', source: 'owner/repo' });
     });
 
@@ -83,7 +83,7 @@ describe('aidev add skill', () => {
 
       const result = await AddSkill.run(['-n', 'my-skill'], oclifConfig);
 
-      expect(result.success).to.be.true;
+      expect('success' in result && result.success).to.be.true;
       expect(installStub.firstCall.args[0]).to.equal('my-skill');
     });
 


### PR DESCRIPTION
## Summary

- Add Escape key handling to all interactive prompts (select, checkbox, confirm)
  - `@inquirer/prompts` v8 doesn't handle Escape natively, only Ctrl+C
  - Added `withEscapeHandling()` wrapper that listens for Escape and calls `cancel()`
  - Updated error handling to catch both `ExitPromptError` and `CancelPromptError`

- Add interactive mode to add subcommands (`skill`, `agent`, `prompt`)
  - Commands now work without `--name` flag, showing checkbox selection
  - Filters artifacts to only the specific type
  - Same UI as parent `sf aidev add` command
  - `--name` flag still works for direct non-interactive installation

- Export new utility functions from `interactivePrompts.ts`:
  - `promptConfirm()` - confirmation dialog with Escape support
  - `promptCheckboxGeneric<T>()` - generic checkbox with Escape support

- Update remove command to use new `promptConfirm` wrapper

## Test plan

- [x] Verify Escape key exits interactive mode in `sf aidev list`
- [x] Verify Escape key exits interactive mode in `sf aidev add`
- [x] Verify Escape key exits interactive mode in `sf aidev remove`
- [x] Verify `sf aidev add skill` without `--name` shows interactive selection
- [x] Verify `sf aidev add agent` without `--name` shows interactive selection
- [x] Verify `sf aidev add prompt` without `--name` shows interactive selection
- [x] Verify `sf aidev add skill --name X` still works (direct mode)
- [x] All existing tests pass

Closes #82, #83

🤖 Generated with [Claude Code](https://claude.com/claude-code)